### PR TITLE
Create OCR Simulator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@
 
 # Editor specific
 .vscode
+
+# executable output folder
+bin/

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+GOBASE=$(shell pwd)
+GOBIN=$(GOBASE)/bin
+
 GOPACKAGES = $(shell go list ./...)
 
 dependencies:
@@ -12,9 +15,12 @@ coverage:
 benchmark: dependencies fmt
 	@go test $(GOPACKAGES) -bench=. -benchmem -run=^#
 
+simulator: dependencies fmt
+	go build -o $(GOBIN)/simulator ./cmd/simulator/*.go || exit
+
 fmt:
 	gofmt -w .
 
 default: build
 
-.PHONY: dependencies test fmt benchmark
+.PHONY: dependencies test fmt benchmark simulate

--- a/cmd/simulator/controller.go
+++ b/cmd/simulator/controller.go
@@ -1,0 +1,290 @@
+package main
+
+import (
+	"context"
+	"log"
+	"sync"
+	"time"
+)
+
+type OCRCallBase struct {
+	Context context.Context
+	Round   int
+	Epoch   int
+}
+
+type OCRCall[T OCRQuery | []OCRObservation | OCRReport | struct{}] struct {
+	OCRCallBase
+	Data T
+}
+
+type OCRQuery []byte
+type OCRObservation []byte
+type OCRReport []byte
+
+type OCRController struct {
+	RoundTime       time.Duration
+	Queries         chan OCRQuery
+	Observations    chan OCRObservation
+	Reports         chan OCRReport
+	Stop            chan struct{}
+	Receivers       []*OCRReceiver
+	MaxRounds       int
+	mu              sync.Mutex
+	collection      []OCRObservation
+	completeReports [][]OCRReport
+}
+
+func NewOCRController(round time.Duration, rnds int, rcvrs ...*OCRReceiver) *OCRController {
+	return &OCRController{
+		RoundTime:       round,
+		Queries:         make(chan OCRQuery, 1),
+		Observations:    make(chan OCRObservation, len(rcvrs)),
+		Reports:         make(chan OCRReport, len(rcvrs)),
+		Stop:            make(chan struct{}, 1),
+		Receivers:       rcvrs,
+		MaxRounds:       rnds,
+		collection:      []OCRObservation{},
+		completeReports: [][]OCRReport{},
+	}
+}
+
+func (c *OCRController) sendInitCall(ctx context.Context, call OCRCallBase) {
+	var wg sync.WaitGroup
+
+	// TODO: pick randomly from available recievers
+	// send init call to single node in receivers
+	// mimicks leader selection in OCR
+	wg.Add(1)
+
+	go func(r *OCRReceiver) {
+		defer wg.Done()
+
+		select {
+		case r.Init <- OCRCall[struct{}]{OCRCallBase: call, Data: struct{}{}}:
+			log.Printf("controller: init call sent to %s", r.Name)
+			return
+		case <-ctx.Done():
+			return
+		}
+	}(c.Receivers[0])
+
+	wg.Wait()
+}
+
+func (c *OCRController) sendQueries(ctx context.Context, call OCRCallBase) {
+	var wg sync.WaitGroup
+
+	select {
+	case q := <-c.Queries:
+		log.Printf("controller: received query from leader")
+		for _, rec := range c.Receivers {
+			wg.Add(1)
+
+			go func(r *OCRReceiver) {
+				defer wg.Done()
+
+				select {
+				case r.Query <- OCRCall[OCRQuery]{OCRCallBase: call, Data: q}:
+					log.Printf("controller: sent query to %s", r.Name)
+					return
+				case <-ctx.Done():
+					return
+				}
+			}(rec)
+		}
+
+		wg.Wait()
+	case <-ctx.Done():
+		return
+	}
+}
+
+func (c *OCRController) collectObservations(ctx context.Context) {
+	var wg sync.WaitGroup
+
+	c.mu.Lock()
+	c.collection = make([]OCRObservation, len(c.Receivers))
+	c.mu.Unlock()
+
+	for j := 0; j < len(c.Receivers); j++ {
+		wg.Add(1)
+
+		go func(idx int) {
+			defer wg.Done()
+
+			select {
+			case o := <-c.Observations:
+				log.Printf("controller: received observation from %s", c.Receivers[idx].Name)
+				c.mu.Lock()
+				c.collection[idx] = o
+				c.mu.Unlock()
+				return
+			case <-ctx.Done():
+				return
+			}
+		}(j)
+	}
+
+	wg.Wait()
+}
+
+func (c *OCRController) sendObservations(ctx context.Context, call OCRCallBase) {
+	var wg sync.WaitGroup
+
+	// send observations to all nodes
+	c.mu.Lock()
+	copy := c.collection
+	c.mu.Unlock()
+
+	for _, rec := range c.Receivers {
+		wg.Add(1)
+
+		go func(r *OCRReceiver) {
+			defer wg.Done()
+
+			select {
+			case r.Observations <- OCRCall[[]OCRObservation]{OCRCallBase: call, Data: copy}:
+				log.Printf("controller: sent observations to %s", r.Name)
+				return
+			case <-ctx.Done():
+				return
+			}
+		}(rec)
+	}
+
+	wg.Wait()
+}
+
+func (c *OCRController) collectReports(ctx context.Context, call OCRCallBase) {
+	var wg sync.WaitGroup
+
+	stp, isSet := ctx.Deadline()
+	if !isSet {
+		stp = time.Now()
+	}
+
+	stp = stp.Add(-1 * time.Duration(len(c.Receivers)) * 20 * time.Millisecond)
+
+	if stp.Before(time.Now()) {
+		return
+	}
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		rpts := []OCRReport{}
+
+	Outer:
+		for i := 0; i < len(c.Receivers); i++ {
+			select {
+			case r := <-c.Reports:
+				log.Printf("controller: report received from %s", c.Receivers[i].Name)
+				rpts = append(rpts, r)
+			case <-ctx.Done():
+				break Outer
+			}
+		}
+
+		c.mu.Lock()
+		c.completeReports = append(c.completeReports, rpts)
+		c.mu.Unlock()
+	}()
+	wg.Wait()
+
+	c.mu.Lock()
+	if len(c.completeReports[len(c.completeReports)-1]) > 0 {
+		rpt := c.collapseReports(c.completeReports[len(c.completeReports)-1])
+
+		for _, rec := range c.Receivers {
+			wg.Add(1)
+			go func(r *OCRReceiver) {
+				defer wg.Done()
+
+				select {
+				case r.Report <- OCRCall[OCRReport]{OCRCallBase: call, Data: rpt}:
+					log.Printf("controller: sent final report to %s", r.Name)
+					return
+				case <-ctx.Done():
+					return
+				}
+			}(rec)
+		}
+	}
+	c.mu.Unlock()
+
+	wg.Wait()
+}
+
+func (c *OCRController) collapseReports(reports []OCRReport) OCRReport {
+	// TODO: nieve implementation assumes are reports are the same and sends the first
+	return reports[0]
+}
+
+func (c *OCRController) stopReceivers() {
+	for _, rec := range c.Receivers {
+		go func(r *OCRReceiver) {
+			r.Stop <- struct{}{}
+		}(rec)
+	}
+}
+
+func (c *OCRController) Start(ctx context.Context) chan struct{} {
+	done := make(chan struct{}, 1)
+
+	go func() {
+		//tkr := time.NewTicker(c.RoundTime)
+		tkr := 0 * time.Second
+		iterations := 0
+
+		log.Printf("starting OCR controller with round time of %d seconds", c.RoundTime/time.Second)
+
+		for {
+			t := time.NewTimer(tkr)
+
+			select {
+			case <-c.Stop:
+				log.Printf("receivers stopping")
+				c.stopReceivers()
+				log.Printf("receivers stopped")
+				t.Stop()
+				done <- struct{}{}
+				return
+			case <-t.C:
+				iterations++
+				roundCtx, cancel := context.WithDeadline(ctx, time.Now().Add(c.RoundTime-(10*time.Millisecond)))
+				base := OCRCallBase{Context: roundCtx, Round: iterations, Epoch: 1}
+
+				log.Printf("-----> round %d begins", iterations)
+
+				// send call to Query to begin round
+				c.sendInitCall(roundCtx, base)
+
+				// send Query to all recievers to begin creating Observations
+				c.sendQueries(roundCtx, base)
+
+				// collect all observations from receivers
+				c.collectObservations(roundCtx)
+
+				// send observations to all receivers
+				c.sendObservations(roundCtx, base)
+
+				c.collectReports(roundCtx, base)
+
+				log.Printf("<----- round %d ends", iterations)
+				if c.MaxRounds > 0 && iterations == c.MaxRounds {
+					log.Printf("max rounds encountered; terminating process")
+					c.Stop <- struct{}{}
+				}
+				tkr = c.RoundTime
+				cancel()
+			case <-ctx.Done():
+				// stop all receivers
+				c.Stop <- struct{}{}
+			}
+		}
+	}()
+
+	return done
+}

--- a/cmd/simulator/controller_test.go
+++ b/cmd/simulator/controller_test.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMockCollectObservations(t *testing.T) {
+	r1 := NewOCRReceiver("1")
+	r2 := NewOCRReceiver("2")
+
+	duration := 100 * time.Millisecond
+	c := NewOCRController(duration, 2, r1, r2)
+
+	c.Observations <- OCRObservation([]byte("one"))
+	c.Observations <- OCRObservation([]byte("two"))
+
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(10*time.Millisecond))
+	c.collectObservations(ctx)
+	cancel()
+
+	assert.Contains(t, c.collection, OCRObservation([]byte("one")))
+	assert.Contains(t, c.collection, OCRObservation([]byte("two")))
+}
+
+func TestMockSendObservations(t *testing.T) {
+	r1 := NewOCRReceiver("1")
+	r2 := NewOCRReceiver("2")
+
+	duration := 100 * time.Millisecond
+	c := NewOCRController(duration, 2, r1, r2)
+
+	c.collection = []OCRObservation{OCRObservation([]byte("one")), OCRObservation([]byte("two"))}
+
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(200*time.Millisecond))
+	base := OCRCallBase{Context: ctx, Round: 1, Epoch: 1}
+	c.sendObservations(ctx, base)
+
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		select {
+		case a := <-r1.Observations:
+			assert.Equal(t, a.Data, c.collection)
+		case <-ctx.Done():
+			assert.Fail(t, "missing observation for r1")
+			return
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		select {
+		case a := <-r2.Observations:
+			assert.Equal(t, a.Data, c.collection)
+		case <-ctx.Done():
+			assert.Fail(t, "missing observation for r2")
+			return
+		}
+	}()
+
+	wg.Wait()
+	cancel()
+}
+
+func TestMockCollectReports(t *testing.T) {
+	r1 := NewOCRReceiver("1")
+	r2 := NewOCRReceiver("2")
+
+	duration := 100 * time.Millisecond
+	c := NewOCRController(duration, 2, r1, r2)
+
+	c.Reports <- OCRReport([]byte("one"))
+	c.Reports <- OCRReport([]byte("two"))
+
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(200*time.Millisecond))
+	base := OCRCallBase{Context: ctx, Round: 1, Epoch: 1}
+	c.collectReports(ctx, base)
+
+	var wg sync.WaitGroup
+
+	if len(c.completeReports) > 0 {
+		assert.Contains(t, c.completeReports[0], OCRReport([]byte("one")))
+		assert.Contains(t, c.completeReports[0], OCRReport([]byte("two")))
+	} else {
+		assert.Fail(t, "missing complete reports")
+	}
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		select {
+		case a := <-r1.Report:
+			assert.Equal(t, a.Data, c.completeReports[0][0])
+		case <-ctx.Done():
+			assert.Fail(t, "missing report for r1")
+			return
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		select {
+		case a := <-r2.Report:
+			assert.Equal(t, a.Data, c.completeReports[0][0])
+		case <-ctx.Done():
+			assert.Fail(t, "missing report for r2")
+			return
+		}
+	}()
+
+	wg.Wait()
+	cancel()
+}

--- a/cmd/simulator/main.go
+++ b/cmd/simulator/main.go
@@ -1,0 +1,163 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/smartcontractkit/libocr/offchainreporting2/types"
+	"github.com/smartcontractkit/ocr2keepers/internal/keepers"
+	"github.com/smartcontractkit/ocr2keepers/pkg/chain"
+)
+
+var (
+	contract = flag.String("contract", "", "contract address")
+	rpc      = flag.String("rpc", "https://rinkeby.infura.io", "rpc host to make calls")
+	nodes    = flag.Int("nodes", 3, "number of nodes to simulate")
+	rounds   = flag.Int("rounds", 2, "OCR rounds to simulate; 0 for no limit")
+	rtime    = flag.Int("round-time", 5, "round time in seconds")
+)
+
+func main() {
+	flag.Parse()
+
+	if contract == nil || *contract == "" {
+		panic("contract must be defined")
+	}
+
+	if rpc == nil || *rpc == "" {
+		panic("rpc must be defined")
+	}
+
+	address := common.HexToAddress(*contract)
+	receivers := make([]*OCRReceiver, *nodes)
+	for i := 0; i < *nodes; i++ {
+		receivers[i] = NewOCRReceiver(fmt.Sprintf("node %d", i+1))
+	}
+
+	t := time.Duration(int64(*rtime))
+	controller := NewOCRController(t*time.Second, *rounds, receivers...)
+
+	for _, rec := range receivers {
+		wrapPluginReceiver(controller, rec, makePlugin(address))
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+
+	c := make(chan os.Signal, 1) // we need to reserve to buffer size 1, so the notifier are not blocked
+	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
+
+	select {
+	case <-controller.Start(ctx):
+		log.Printf("done signal encountered")
+		cancel()
+	case <-ctx.Done():
+		cancel()
+	case <-c:
+		cancel()
+	}
+}
+
+func makePlugin(address common.Address) types.ReportingPlugin {
+	client, err := ethclient.Dial(*rpc)
+	if err != nil {
+		panic(err)
+	}
+
+	reg, err := chain.NewEVMRegistryV1_2(address, client)
+	if err != nil {
+		panic(err)
+	}
+
+	factory := keepers.NewReportingPluginFactory(reg, chain.NewEVMReportEncoder())
+	plugin, _, err := factory.NewReportingPlugin(types.ReportingPluginConfig{})
+	if err != nil {
+		panic(err)
+	}
+
+	return plugin
+}
+
+func wrapPluginReceiver(controller *OCRController, receiver *OCRReceiver, plugin types.ReportingPlugin) {
+	go func(c *OCRController, r *OCRReceiver, p types.ReportingPlugin) {
+		for {
+			select {
+			case call := <-receiver.Init:
+				log.Printf("%s: init call received", receiver.Name)
+				q, err := p.Query(call.Context, types.ReportTimestamp{Round: uint8(call.Round), Epoch: uint32(call.Epoch)})
+				if err != nil {
+					log.Printf("fatal error in query: %s", err)
+					return
+				}
+				go func() {
+					select {
+					case c.Queries <- OCRQuery(q):
+						log.Printf("%s: sent query to controller", receiver.Name)
+						return
+					case <-call.Context.Done():
+						return
+					}
+				}()
+			case call := <-receiver.Query:
+				log.Printf("%s: query recieved", receiver.Name)
+				o, err := p.Observation(call.Context, types.ReportTimestamp{Round: uint8(call.Round), Epoch: uint32(call.Epoch)}, types.Query(call.Data))
+				if err != nil {
+					log.Printf("fatal error in query: %s", err)
+				}
+				go func() {
+					select {
+					case c.Observations <- OCRObservation(o):
+						log.Printf("%s: sent observation to controller", receiver.Name)
+						return
+					case <-call.Context.Done():
+						return
+					}
+				}()
+			case call := <-receiver.Observations:
+				log.Printf("%s: observations received", receiver.Name)
+				attr := make([]types.AttributedObservation, len(call.Data))
+				for i, o := range call.Data {
+					attr[i] = types.AttributedObservation{
+						Observation: types.Observation(o),
+					}
+				}
+
+				b, r, err := p.Report(call.Context, types.ReportTimestamp{Round: uint8(call.Round), Epoch: uint32(call.Epoch)}, types.Query{}, attr)
+				if err != nil {
+					log.Printf("fatal error in query: %s", err)
+				}
+
+				go func() {
+					rv := types.Report{}
+					if b {
+						rv = r
+					}
+					select {
+					case c.Reports <- OCRReport(rv):
+						log.Printf("%s: sent report to controller", receiver.Name)
+						return
+					case <-call.Context.Done():
+						return
+					}
+				}()
+			case call := <-receiver.Report:
+				log.Printf("%s: report received", receiver.Name)
+				b, err := p.ShouldAcceptFinalizedReport(call.Context, types.ReportTimestamp{Round: uint8(call.Round), Epoch: uint32(call.Epoch)}, types.Report(call.Data))
+				if err != nil {
+					log.Printf("fatal error in query: %s", err)
+				}
+
+				log.Printf("accept finalized report for round: %d; epoch: %d: %t", call.Round, call.Epoch, b)
+			case <-r.Stop:
+				return
+			}
+		}
+	}(controller, receiver, plugin)
+}

--- a/cmd/simulator/receiver.go
+++ b/cmd/simulator/receiver.go
@@ -1,0 +1,21 @@
+package main
+
+type OCRReceiver struct {
+	Name         string
+	Init         chan OCRCall[struct{}]
+	Query        chan OCRCall[OCRQuery]
+	Observations chan OCRCall[[]OCRObservation]
+	Report       chan OCRCall[OCRReport]
+	Stop         chan struct{}
+}
+
+func NewOCRReceiver(name string) *OCRReceiver {
+	return &OCRReceiver{
+		Name:         name,
+		Init:         make(chan OCRCall[struct{}], 1),
+		Query:        make(chan OCRCall[OCRQuery], 1),
+		Observations: make(chan OCRCall[[]OCRObservation], 1),
+		Report:       make(chan OCRCall[OCRReport], 1),
+		Stop:         make(chan struct{}),
+	}
+}


### PR DESCRIPTION
This simulator runs a simulated OCR process that steps through the Query, Observation, Report steps to produce reports destined for a contract. This simulator does not commit anything and does not sign observations or reports.

Run a simulation of multiple nodes querying the underlying chain data set in the context of OCR epochs and rounds.