### PR TITLE
Feature/add config params

### DIFF
--- a/cmd/simulator/controller.go
+++ b/cmd/simulator/controller.go
@@ -353,7 +353,7 @@ func (c *OCRController) WriteReports(path string) {
 	c.mu.Lock()
 	for i, nodeReports := range c.completeReports {
 		for j, r := range nodeReports {
-			name := fmt.Sprintf("node_%d_round_%d", i+1, j+1)
+			name := fmt.Sprintf("node_%d_round_%d", j+1, i+1)
 
 			dst := make([]byte, hex.EncodedLen(len(r)))
 			hex.Encode(dst, r)

--- a/cmd/simulator/full.go
+++ b/cmd/simulator/full.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"os/signal"
+	"runtime"
 	"runtime/debug"
 	"syscall"
 	"time"
@@ -212,7 +213,14 @@ func makePlugin(address common.Address, controller *OCRController, logger *log.L
 		panic(err)
 	}
 
-	factory := keepers.NewReportingPluginFactory(reg, chain.NewEVMReportEncoder(), logger, 30*time.Second)
+	config := keepers.ReportingFactoryConfig{
+		CacheExpiration:       20 * time.Minute,
+		CacheEvictionInterval: 30 * time.Second,
+		MaxServiceWorkers:     10 * runtime.GOMAXPROCS(0),
+		ServiceQueueLength:    1000,
+	}
+
+	factory := keepers.NewReportingPluginFactory(reg, chain.NewEVMReportEncoder(), logger, config)
 	plugin, info, err := factory.NewReportingPlugin(types.ReportingPluginConfig{})
 	if err != nil {
 		panic(err)

--- a/cmd/simulator/full.go
+++ b/cmd/simulator/full.go
@@ -212,7 +212,7 @@ func makePlugin(address common.Address, controller *OCRController, logger *log.L
 		panic(err)
 	}
 
-	factory := keepers.NewReportingPluginFactory(reg, chain.NewEVMReportEncoder(), logger)
+	factory := keepers.NewReportingPluginFactory(reg, chain.NewEVMReportEncoder(), logger, 30*time.Second)
 	plugin, info, err := factory.NewReportingPlugin(types.ReportingPluginConfig{})
 	if err != nil {
 		panic(err)

--- a/cmd/simulator/full.go
+++ b/cmd/simulator/full.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/smartcontractkit/libocr/commontypes"
 	"github.com/smartcontractkit/libocr/offchainreporting2/types"
 	"github.com/smartcontractkit/ocr2keepers/internal/keepers"
 	"github.com/smartcontractkit/ocr2keepers/pkg/chain"
@@ -171,7 +172,7 @@ func runFullSimulation(logger *log.Logger, config *SimulatorConfig) error {
 			return err
 		}
 
-		wrapPluginReceiver(simLogger, controller, rec, makePlugin(address, controller, l, client))
+		wrapPluginReceiver(simLogger, controller, rec, makePlugin(address, controller, l, client, int8(i), *config.Nodes))
 	}
 
 	var ctx context.Context
@@ -207,7 +208,7 @@ func runFullSimulation(logger *log.Logger, config *SimulatorConfig) error {
 	return nil
 }
 
-func makePlugin(address common.Address, controller *OCRController, logger *log.Logger, client *ethclient.Client) types.ReportingPlugin {
+func makePlugin(address common.Address, controller *OCRController, logger *log.Logger, client *ethclient.Client, i int8, n int) types.ReportingPlugin {
 	reg, err := chain.NewEVMRegistryV2_0(address, client)
 	if err != nil {
 		panic(err)
@@ -221,7 +222,12 @@ func makePlugin(address common.Address, controller *OCRController, logger *log.L
 	}
 
 	factory := keepers.NewReportingPluginFactory(reg, chain.NewEVMReportEncoder(), logger, config)
-	plugin, info, err := factory.NewReportingPlugin(types.ReportingPluginConfig{})
+	plugin, info, err := factory.NewReportingPlugin(types.ReportingPluginConfig{
+		ConfigDigest: types.ConfigDigest([32]byte{}),
+		OracleID:     commontypes.OracleID(i),
+		N:            n,
+		F:            0,
+	})
 	if err != nil {
 		panic(err)
 	}

--- a/internal/keepers/factory.go
+++ b/internal/keepers/factory.go
@@ -3,43 +3,46 @@ package keepers
 import (
 	"fmt"
 	"log"
-	"runtime"
 	"time"
 
 	"github.com/smartcontractkit/libocr/offchainreporting2/types"
 	ktypes "github.com/smartcontractkit/ocr2keepers/pkg/types"
 )
 
+type ReportingFactoryConfig struct {
+	CacheExpiration       time.Duration
+	CacheEvictionInterval time.Duration
+	MaxServiceWorkers     int
+	ServiceQueueLength    int
+}
+
 // NewReportingPluginFactory returns an OCR ReportingPluginFactory. When the plugin
 // starts, a separate service is started as a separate go-routine automatically. There
 // is no start or stop function for this service so stopping this service relies on
 // releasing references to the plugin such that the Go garbage collector cleans up
 // hanging routines automatically.
-func NewReportingPluginFactory(registry ktypes.Registry, encoder ktypes.ReportEncoder, logger *log.Logger, clearCacheInterval time.Duration) types.ReportingPluginFactory {
-	return &keepersReportingFactory{
-		registry:   registry,
-		encoder:    encoder,
-		logger:     logger,
-		clearCache: clearCacheInterval,
-	}
+func NewReportingPluginFactory(registry ktypes.Registry, encoder ktypes.ReportEncoder, logger *log.Logger, config ReportingFactoryConfig) types.ReportingPluginFactory {
+	return &keepersReportingFactory{registry: registry, encoder: encoder, logger: logger, config: config}
 }
 
 type keepersReportingFactory struct {
-	registry   ktypes.Registry
-	encoder    ktypes.ReportEncoder
-	logger     *log.Logger
-	clearCache time.Duration
+	registry ktypes.Registry
+	encoder  ktypes.ReportEncoder
+	logger   *log.Logger
+	config   ReportingFactoryConfig
 }
 
 var _ types.ReportingPluginFactory = (*keepersReportingFactory)(nil)
 
 // NewReportingPlugin implements the libocr/offchainreporting2/types ReportingPluginFactory interface
 func (d *keepersReportingFactory) NewReportingPlugin(c types.ReportingPluginConfig) (types.ReportingPlugin, types.ReportingPluginInfo, error) {
-	var offChainCfg offChainConfig
-	err := decode(c.OffchainConfig, &offChainCfg)
-	if err != nil {
-		return nil, types.ReportingPluginInfo{}, fmt.Errorf("%w: failed to decode off chain config", err)
-	}
+	/*
+		var offChainCfg offChainConfig
+		err := decode(c.OffchainConfig, &offChainCfg)
+		if err != nil {
+			return nil, types.ReportingPluginInfo{}, fmt.Errorf("%w: failed to decode off chain config", err)
+		}
+	*/
 
 	info := types.ReportingPluginInfo{
 		Name: fmt.Sprintf("Oracle %d: Keepers Plugin Instance w/ Digest '%s'", c.OracleID, c.ConfigDigest),
@@ -53,33 +56,33 @@ func (d *keepersReportingFactory) NewReportingPlugin(c types.ReportingPluginConf
 			MaxObservationLength: 1_000,
 			// a report is composed of 1 or more abi encoded perform calls
 			// with performData of arbitrary length
-			MaxReportLength: 10_000, // TODO (config): pick sane limit based on expected performData size. maybe set this to block size limit?
+			MaxReportLength: 10_000, // TODO (config): pick sane limit based on expected performData size. maybe set this to block size limit or 2/3 block size limit?
 		},
+		// TODO: unique reports may need to be a configuration param from
+		// offChainConfig or onChainConfig
 		// unique reports ensures that each round produces only a single report
 		UniqueReports: true,
 	}
 
-	// TODO (config): cache expiration should be configurable based on offchain
-	// config, block time, round time, or other environmental condition
-	cacheExpire := 20 * time.Minute
+	// TODO (config): sample ratio is calculated with number of rounds, number
+	// of nodes, and target probability for all upkeeps to be checked. each
+	// chain will have a different average number of rounds per block. this
+	// number needs to either come from a config, or be calculated on actual
+	// performance of the nodes in real time. that is, start at 1 and increment
+	// after some blocks pass until a stable number is reached.
+	sample, err := sampleFromProbability(1, c.N-c.F, 0.99999)
+	if err != nil {
+		return nil, info, fmt.Errorf("%w: failed to create plugin", err)
+	}
 
-	// TODO (config): number of workers should be based on total amount of resources
-	// available. the work load of checking upkeeps is memory heavy as each work
-	// item is mostly waiting on the network. many work items get staged very
-	// quickly and stay in memory until the network response comes in. from
-	// there it's just a matter of decoding the response.
-	workers := 10 * runtime.GOMAXPROCS(0) // # of workers = 10 * [# of cpus]
-
-	// TODO (config): the worker queue length should be large enough to accomodate the
-	// total number of work items coming in (upkeeps to check per block) without
-	// overrunning memory limits.
-	workerQueueLength := 1000
-
-	// TODO (config): sample ratio should be able to be calculated based on number of
-	// nodes and max number of faulty nodes
-	sample := sampleRatio(0.6)
-
-	service := newSimpleUpkeepService(sample, d.registry, d.logger, cacheExpire, d.clearCache, workers, workerQueueLength)
+	service := newSimpleUpkeepService(
+		sample,
+		d.registry,
+		d.logger,
+		d.config.CacheExpiration,
+		d.config.CacheEvictionInterval,
+		d.config.MaxServiceWorkers,
+		d.config.ServiceQueueLength)
 
 	return &keepers{service: service, encoder: d.encoder}, info, nil
 }

--- a/internal/keepers/factory.go
+++ b/internal/keepers/factory.go
@@ -36,13 +36,17 @@ var _ types.ReportingPluginFactory = (*keepersReportingFactory)(nil)
 
 // NewReportingPlugin implements the libocr/offchainreporting2/types ReportingPluginFactory interface
 func (d *keepersReportingFactory) NewReportingPlugin(c types.ReportingPluginConfig) (types.ReportingPlugin, types.ReportingPluginInfo, error) {
-	/*
-		var offChainCfg offChainConfig
+	var offChainCfg ktypes.OffChainConfig
+	if len(c.OffchainConfig) > 0 {
 		err := decode(c.OffchainConfig, &offChainCfg)
 		if err != nil {
 			return nil, types.ReportingPluginInfo{}, fmt.Errorf("%w: failed to decode off chain config", err)
 		}
-	*/
+	}
+
+	if offChainCfg.PerformLockoutWindow == 0 {
+		offChainCfg.PerformLockoutWindow = 100 * 12 * 1000
+	}
 
 	info := types.ReportingPluginInfo{
 		Name: fmt.Sprintf("Oracle %d: Keepers Plugin Instance w/ Digest '%s'", c.OracleID, c.ConfigDigest),
@@ -80,6 +84,7 @@ func (d *keepersReportingFactory) NewReportingPlugin(c types.ReportingPluginConf
 		d.registry,
 		d.logger,
 		d.config.CacheExpiration,
+		time.Duration(offChainCfg.PerformLockoutWindow)*time.Millisecond,
 		d.config.CacheEvictionInterval,
 		d.config.MaxServiceWorkers,
 		d.config.ServiceQueueLength)

--- a/internal/keepers/factory.go
+++ b/internal/keepers/factory.go
@@ -84,5 +84,5 @@ func (d *keepersReportingFactory) NewReportingPlugin(c types.ReportingPluginConf
 		d.config.MaxServiceWorkers,
 		d.config.ServiceQueueLength)
 
-	return &keepers{service: service, encoder: d.encoder}, info, nil
+	return &keepers{service: service, encoder: d.encoder, logger: d.logger}, info, nil
 }

--- a/internal/keepers/factory_test.go
+++ b/internal/keepers/factory_test.go
@@ -2,14 +2,13 @@ package keepers
 
 import (
 	"testing"
-	"time"
 
 	"github.com/smartcontractkit/libocr/offchainreporting2/types"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestNewReportingPluginFactory(t *testing.T) {
-	f := NewReportingPluginFactory(nil, nil, nil, 30*time.Second)
+	f := NewReportingPluginFactory(nil, nil, nil, ReportingFactoryConfig{})
 	assert.NotNil(t, f)
 }
 

--- a/internal/keepers/factory_test.go
+++ b/internal/keepers/factory_test.go
@@ -2,13 +2,14 @@ package keepers
 
 import (
 	"testing"
+	"time"
 
 	"github.com/smartcontractkit/libocr/offchainreporting2/types"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestNewReportingPluginFactory(t *testing.T) {
-	f := NewReportingPluginFactory(nil, nil, nil)
+	f := NewReportingPluginFactory(nil, nil, nil, 30*time.Second)
 	assert.NotNil(t, f)
 }
 

--- a/internal/keepers/factory_test.go
+++ b/internal/keepers/factory_test.go
@@ -29,10 +29,11 @@ func TestNewReportingPlugin(t *testing.T) {
 	copy(digest[:], []byte(digestStr)[:32])
 
 	p, i, err := f.NewReportingPlugin(types.ReportingPluginConfig{
-		ConfigDigest: digest,
-		OracleID:     1,
-		N:            5,
-		F:            2,
+		ConfigDigest:   digest,
+		OracleID:       1,
+		N:              5,
+		F:              2,
+		OffchainConfig: []byte{},
 	})
 
 	assert.NoError(t, err)

--- a/internal/keepers/factory_test.go
+++ b/internal/keepers/factory_test.go
@@ -1,7 +1,9 @@
 package keepers
 
 import (
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/smartcontractkit/libocr/offchainreporting2/types"
 	"github.com/stretchr/testify/assert"
@@ -13,11 +15,27 @@ func TestNewReportingPluginFactory(t *testing.T) {
 }
 
 func TestNewReportingPlugin(t *testing.T) {
-	f := &keepersReportingFactory{}
+	f := &keepersReportingFactory{
+		config: ReportingFactoryConfig{
+			CacheExpiration:       30 * time.Second,
+			CacheEvictionInterval: 5 * time.Second,
+			MaxServiceWorkers:     1,
+			ServiceQueueLength:    10,
+		},
+	}
 
-	p, i, err := f.NewReportingPlugin(types.ReportingPluginConfig{})
+	digest := [32]byte{}
+	digestStr := fmt.Sprintf("%32s", "test")
+	copy(digest[:], []byte(digestStr)[:32])
+
+	p, i, err := f.NewReportingPlugin(types.ReportingPluginConfig{
+		ConfigDigest: digest,
+		OracleID:     1,
+		N:            5,
+		F:            2,
+	})
 
 	assert.NoError(t, err)
-	assert.Equal(t, "keepers instance TODO: give instance a unique name", i.Name)
+	assert.Equal(t, "Oracle 1: Keepers Plugin Instance w/ Digest '2020202020202020202020202020202020202020202020202020202074657374'", i.Name)
 	assert.NotNil(t, p)
 }

--- a/internal/keepers/keepers.go
+++ b/internal/keepers/keepers.go
@@ -1,12 +1,15 @@
 package keepers
 
 import (
+	"log"
+
 	"github.com/smartcontractkit/ocr2keepers/pkg/types"
 )
 
 type keepers struct {
 	service upkeepService
 	encoder types.ReportEncoder
+	logger  *log.Logger
 }
 
 /*

--- a/internal/keepers/keepers.go
+++ b/internal/keepers/keepers.go
@@ -9,8 +9,10 @@ type keepers struct {
 	encoder types.ReportEncoder
 }
 
+/*
 type offChainConfig struct {
 }
 
 type onChainConfig struct {
 }
+*/

--- a/internal/keepers/keepers.go
+++ b/internal/keepers/keepers.go
@@ -11,11 +11,3 @@ type keepers struct {
 	encoder types.ReportEncoder
 	logger  *log.Logger
 }
-
-/*
-type offChainConfig struct {
-}
-
-type onChainConfig struct {
-}
-*/

--- a/internal/keepers/keepers.go
+++ b/internal/keepers/keepers.go
@@ -8,3 +8,9 @@ type keepers struct {
 	service upkeepService
 	encoder types.ReportEncoder
 }
+
+type offChainConfig struct {
+}
+
+type onChainConfig struct {
+}

--- a/internal/keepers/ocr.go
+++ b/internal/keepers/ocr.go
@@ -55,6 +55,7 @@ func (k *keepers) Report(ctx context.Context, _ types.ReportTimestamp, _ types.Q
 
 		if upkeep.State == ktypes.Perform {
 			// only build a report from a single upkeep for now
+			k.logger.Printf("reporting %s to be performed", upkeep.Key)
 			toPerform = append(toPerform, upkeep)
 			break
 		}

--- a/internal/keepers/ocr_test.go
+++ b/internal/keepers/ocr_test.go
@@ -3,6 +3,8 @@ package keepers
 import (
 	"context"
 	"fmt"
+	"io"
+	"log"
 	"testing"
 	"time"
 
@@ -14,7 +16,9 @@ import (
 )
 
 func TestQuery(t *testing.T) {
-	plugin := &keepers{}
+	plugin := &keepers{
+		logger: log.New(io.Discard, "", 0),
+	}
 	b, err := plugin.Query(context.Background(), types.ReportTimestamp{})
 
 	assert.NoError(t, err)
@@ -22,7 +26,9 @@ func TestQuery(t *testing.T) {
 }
 
 func BenchmarkQuery(b *testing.B) {
-	plugin := &keepers{}
+	plugin := &keepers{
+		logger: log.New(io.Discard, "", 0),
+	}
 
 	// run the Query function b.N times
 	for n := 0; n < b.N; n++ {
@@ -85,7 +91,10 @@ func TestObservation(t *testing.T) {
 	for i, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
 			ms := new(MockedUpkeepService)
-			plugin := &keepers{service: ms}
+			plugin := &keepers{
+				service: ms,
+				logger:  log.New(io.Discard, "", 0),
+			}
 
 			ctx, cancel := test.Ctx()
 			ms.Mock.On("SampleUpkeeps", ctx).Return(test.SampleSet, test.SampleErr)
@@ -109,7 +118,10 @@ func TestObservation(t *testing.T) {
 
 func BenchmarkObservation(b *testing.B) {
 	ms := new(MockedUpkeepService)
-	plugin := &keepers{service: ms}
+	plugin := &keepers{
+		service: ms,
+		logger:  log.New(io.Discard, "", 0),
+	}
 
 	set := make([]*ktypes.UpkeepResult, 2, 100)
 	set[0] = &ktypes.UpkeepResult{Key: ktypes.UpkeepKey([]byte("1|1")), State: ktypes.Perform}
@@ -330,7 +342,11 @@ func TestReport(t *testing.T) {
 			ms := new(MockedUpkeepService)
 			me := new(MockedReportEncoder)
 
-			plugin := &keepers{service: ms, encoder: me}
+			plugin := &keepers{
+				service: ms,
+				encoder: me,
+				logger:  log.New(io.Discard, "", 0),
+			}
 			ctx, cancel := test.Ctx()
 
 			// set up upkeep checks with the mocked service
@@ -374,7 +390,11 @@ func TestReport(t *testing.T) {
 func BenchmarkReport(b *testing.B) {
 	ms := &BenchmarkMockUpkeepService{}
 	me := &BenchmarkMockedReportEncoder{}
-	plugin := &keepers{service: ms, encoder: me}
+	plugin := &keepers{
+		service: ms,
+		encoder: me,
+		logger:  log.New(io.Discard, "", 0),
+	}
 
 	key1 := ktypes.UpkeepKey([]byte("1|1"))
 	key2 := ktypes.UpkeepKey([]byte("1|2"))
@@ -432,7 +452,9 @@ func BenchmarkReport(b *testing.B) {
 }
 
 func TestShouldAcceptFinalizedReport(t *testing.T) {
-	plugin := &keepers{}
+	plugin := &keepers{
+		logger: log.New(io.Discard, "", 0),
+	}
 	ok, err := plugin.ShouldAcceptFinalizedReport(context.Background(), types.ReportTimestamp{}, types.Report{})
 
 	assert.Equal(t, true, ok)
@@ -440,7 +462,9 @@ func TestShouldAcceptFinalizedReport(t *testing.T) {
 }
 
 func BenchmarkShouldAcceptFinalizedReport(b *testing.B) {
-	plugin := &keepers{}
+	plugin := &keepers{
+		logger: log.New(io.Discard, "", 0),
+	}
 
 	// run the ShouldAcceptFinalizedReport function b.N times
 	for n := 0; n < b.N; n++ {
@@ -460,7 +484,9 @@ func TestShouldTransmitAcceptedReport(t *testing.T) {
 }
 
 func BenchmarkShouldTransmitAcceptedReport(b *testing.B) {
-	plugin := &keepers{}
+	plugin := &keepers{
+		logger: log.New(io.Discard, "", 0),
+	}
 
 	// run the ShouldTransmitAcceptedReport function b.N times
 	for n := 0; n < b.N; n++ {

--- a/internal/keepers/service.go
+++ b/internal/keepers/service.go
@@ -12,8 +12,6 @@ import (
 	"github.com/smartcontractkit/ocr2keepers/pkg/types"
 )
 
-const defaultStaleWindow = 100 * 14 * time.Second // 100 blocks @ 14s per block
-
 type simpleUpkeepService struct {
 	logger       *log.Logger
 	ratio        sampleRatio
@@ -32,14 +30,14 @@ type simpleUpkeepService struct {
 // an RPC call.
 //
 // DO NOT USE THIS IN PRODUCTION
-func newSimpleUpkeepService(ratio sampleRatio, registry types.Registry, logger *log.Logger, cacheExpire time.Duration, cacheClean time.Duration, workers int, workerQueueLength int) *simpleUpkeepService {
+func newSimpleUpkeepService(ratio sampleRatio, registry types.Registry, logger *log.Logger, cacheExpire time.Duration, staleWindow time.Duration, cacheClean time.Duration, workers int, workerQueueLength int) *simpleUpkeepService {
 	s := &simpleUpkeepService{
 		logger:     logger,
 		ratio:      ratio,
 		registry:   registry,
 		shuffler:   new(cryptoShuffler[types.UpkeepKey]),
 		cache:      newCache[types.UpkeepResult](cacheExpire),
-		stateCache: newCache[types.UpkeepState](defaultStaleWindow),
+		stateCache: newCache[types.UpkeepState](staleWindow),
 		workers:    newWorkerGroup[types.UpkeepResult](workers, workerQueueLength),
 	}
 

--- a/internal/keepers/service.go
+++ b/internal/keepers/service.go
@@ -12,12 +12,15 @@ import (
 	"github.com/smartcontractkit/ocr2keepers/pkg/types"
 )
 
+const defaultStaleWindow = 100 * 14 * time.Second // 100 blocks @ 14s per block
+
 type simpleUpkeepService struct {
 	logger       *log.Logger
 	ratio        sampleRatio
 	registry     types.Registry
 	shuffler     shuffler[types.UpkeepKey]
 	cache        *cache[types.UpkeepResult]
+	stateCache   *cache[types.UpkeepState]
 	cacheCleaner *intervalCacheCleaner[types.UpkeepResult]
 	workers      *workerGroup[types.UpkeepResult]
 }
@@ -31,12 +34,13 @@ type simpleUpkeepService struct {
 // DO NOT USE THIS IN PRODUCTION
 func newSimpleUpkeepService(ratio sampleRatio, registry types.Registry, logger *log.Logger, cacheExpire time.Duration, cacheClean time.Duration, workers int, workerQueueLength int) *simpleUpkeepService {
 	s := &simpleUpkeepService{
-		logger:   logger,
-		ratio:    ratio,
-		registry: registry,
-		shuffler: new(cryptoShuffler[types.UpkeepKey]),
-		cache:    newCache[types.UpkeepResult](cacheExpire),
-		workers:  newWorkerGroup[types.UpkeepResult](workers, workerQueueLength),
+		logger:     logger,
+		ratio:      ratio,
+		registry:   registry,
+		shuffler:   new(cryptoShuffler[types.UpkeepKey]),
+		cache:      newCache[types.UpkeepResult](cacheExpire),
+		stateCache: newCache[types.UpkeepState](defaultStaleWindow),
+		workers:    newWorkerGroup[types.UpkeepResult](workers, workerQueueLength),
 	}
 
 	cl := &intervalCacheCleaner[types.UpkeepResult]{
@@ -79,14 +83,23 @@ func (s *simpleUpkeepService) SampleUpkeeps(ctx context.Context) ([]*types.Upkee
 func (s *simpleUpkeepService) CheckUpkeep(ctx context.Context, key types.UpkeepKey) (types.UpkeepResult, error) {
 	var result types.UpkeepResult
 
+	id, err := s.registry.IdentifierFromKey(key)
+	if err != nil {
+		return result, err
+	}
+	state, stateCached := s.stateCache.Get(string(id))
+
 	result, cached := s.cache.Get(string(key))
 	if cached {
+		if stateCached {
+			result.State = state
+		}
 		return result, nil
 	}
 
 	// check upkeep at block number in key
 	// return result including performData
-	ok, u, err := s.registry.CheckUpkeep(ctx, key)
+	needsPerform, u, err := s.registry.CheckUpkeep(ctx, key)
 	if err != nil {
 		return types.UpkeepResult{}, fmt.Errorf("%w: service failed to check upkeep from registry", err)
 	}
@@ -96,9 +109,13 @@ func (s *simpleUpkeepService) CheckUpkeep(ctx context.Context, key types.UpkeepK
 		State: types.Skip,
 	}
 
-	if ok {
+	if needsPerform {
 		result.State = types.Perform
 		result.PerformData = u.PerformData
+	}
+
+	if stateCached {
+		result.State = state
 	}
 
 	s.cache.Set(string(key), result, defaultExpiration)
@@ -108,6 +125,15 @@ func (s *simpleUpkeepService) CheckUpkeep(ctx context.Context, key types.UpkeepK
 
 func (s *simpleUpkeepService) SetUpkeepState(ctx context.Context, uk types.UpkeepKey, state types.UpkeepState) error {
 	var err error
+
+	id, err := s.registry.IdentifierFromKey(uk)
+	if err != nil {
+		return err
+	}
+
+	// set the state cache to the default expiration using the upkeep identifer
+	// as the key
+	s.stateCache.Set(string(id), state, defaultExpiration)
 
 	result, cached := s.cache.Get(string(uk))
 	if !cached {
@@ -147,6 +173,8 @@ func (s *simpleUpkeepService) parallelCheck(ctx context.Context, keys []types.Up
 				wg.Done()
 				if result.Err == nil {
 					success++
+					// cache results
+					s.cache.Set(string(result.Data.Key), result.Data, defaultExpiration)
 					if result.Data.State == types.Perform {
 						sample = append(sample, &result.Data)
 					}
@@ -165,6 +193,17 @@ func (s *simpleUpkeepService) parallelCheck(ctx context.Context, keys []types.Up
 	// go through keys and check the cache first
 	// if an item doesn't exist on the cache, send the items to the worker threads
 	for _, key := range keys {
+		// get reported status and continue if found
+		id, err := s.registry.IdentifierFromKey(key)
+		if err != nil {
+			return sample, err
+		}
+		state, stateCached := s.stateCache.Get(string(id))
+		if stateCached && state == types.Reported {
+			cacheHits++
+			continue
+		}
+
 		// skip if reported
 		result, cached := s.cache.Get(string(key))
 		if cached {
@@ -172,25 +211,26 @@ func (s *simpleUpkeepService) parallelCheck(ctx context.Context, keys []types.Up
 			if result.State == types.Perform {
 				sample = append(sample, &result)
 			}
-		} else {
-			wg.Add(1)
-			if err := s.workers.Do(ctx, makeWorkerFunc(s.logger, s.registry, key, ctx)); err != nil {
-				if errors.Is(err, ErrContextCancelled) {
-					// if the context is cancelled before the work can be
-					// finished, stop adding work and allow existing to finish.
-					// cancelling this context will cancel all waiting worker
-					// functions and have them report immediately. this will
-					// result in a lot of errors in the results collector.
-					s.logger.Printf("context cancelled while attempting to add to queue")
-					wg.Done()
-					break
-				} else {
-					// the worker process has probably stopped so the function
-					// should terminate with an error
-					close(done)
-					return nil, fmt.Errorf("%w: failed to add upkeep check to worker queue", err)
-				}
+			continue
+		}
+
+		wg.Add(1)
+		if err := s.workers.Do(ctx, makeWorkerFunc(s.logger, s.registry, key, ctx)); err != nil {
+			if errors.Is(err, ErrContextCancelled) {
+				// if the context is cancelled before the work can be
+				// finished, stop adding work and allow existing to finish.
+				// cancelling this context will cancel all waiting worker
+				// functions and have them report immediately. this will
+				// result in a lot of errors in the results collector.
+				s.logger.Printf("context cancelled while attempting to add to queue")
+				wg.Done()
+				break
 			}
+
+			// the worker process has probably stopped so the function
+			// should terminate with an error
+			close(done)
+			return nil, fmt.Errorf("%w: failed to add upkeep check to worker queue", err)
 		}
 	}
 

--- a/internal/keepers/util.go
+++ b/internal/keepers/util.go
@@ -4,6 +4,8 @@ import (
 	"crypto/rand"
 	"encoding/binary"
 	"fmt"
+	"math"
+	"math/cmplx"
 	rnd "math/rand"
 	"sort"
 
@@ -137,4 +139,32 @@ func sortedDedupedKeyList(attributed []types.AttributedObservation) ([]ktypes.Up
 	sort.Sort(sortUpkeepKeys(keys))
 
 	return keys, nil
+}
+
+func sampleFromProbability(rounds, nodes int, probability float32) (sampleRatio, error) {
+	var ratio sampleRatio
+
+	if rounds <= 0 {
+		return ratio, fmt.Errorf("number of rounds must be greater than 0")
+	}
+
+	if nodes <= 0 {
+		return ratio, fmt.Errorf("number of nodes must be greater than 0")
+	}
+
+	if probability > 1 || probability <= 0 {
+		return ratio, fmt.Errorf("probability must be less than 1 and greater than 0")
+	}
+
+	var r complex128 = complex(float64(rounds), 0)
+	var n complex128 = complex(float64(nodes), 0)
+	var p complex128 = complex(float64(probability), 0)
+
+	g := -1.0 * (p - 1.0)
+	x := cmplx.Pow(cmplx.Pow(g, 1.0/r), 1.0/n)
+	rat := cmplx.Abs(-1.0 * (x - 1.0))
+	rat = math.Round(rat/0.01) * 0.01
+	ratio = sampleRatio(float32(rat))
+
+	return ratio, nil
 }

--- a/pkg/chain/evmreports_test.go
+++ b/pkg/chain/evmreports_test.go
@@ -1,9 +1,12 @@
 package chain
 
 import (
+	"bytes"
+	"math/big"
 	"math/rand"
 	"testing"
 
+	"github.com/ethereum/go-ethereum/common"
 	ktypes "github.com/smartcontractkit/ocr2keepers/pkg/types"
 	"github.com/stretchr/testify/assert"
 )
@@ -16,13 +19,55 @@ func TestNewEVMEncoder(t *testing.T) {
 func TestEncodeReport(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		input := []ktypes.UpkeepResult{
-			{Key: ktypes.UpkeepKey([]byte("1|1")), PerformData: []byte("hello")},
+			{
+				Key:              ktypes.UpkeepKey([]byte("42|18")),
+				PerformData:      []byte("hello"),
+				FastGasWei:       big.NewInt(16),
+				LinkNative:       big.NewInt(8),
+				CheckBlockNumber: 42,
+				CheckBlockHash:   [32]byte{1},
+			},
+			{
+				Key:              ktypes.UpkeepKey([]byte("43|23")),
+				PerformData:      []byte("long perform data that takes up more than 32 bytes to show how byte arrays are abi encoded. this should take up multiple slots."),
+				FastGasWei:       big.NewInt(16),
+				LinkNative:       big.NewInt(8),
+				CheckBlockNumber: 43,
+				CheckBlockHash:   [32]byte{2},
+			},
 		}
 
 		encoder := &evmReportEncoder{}
 		b, err := encoder.EncodeReport(input)
 
-		expected := []byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x40, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x80, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x20, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x5, 0x68, 0x65, 0x6c, 0x6c, 0x6f, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}
+		buff := new(bytes.Buffer)
+		buff.Write(common.Hex2Bytes("0000000000000000000000000000000000000000000000000000000000000010")) // fastGasWei in hex format
+		buff.Write(common.Hex2Bytes("0000000000000000000000000000000000000000000000000000000000000008")) // linkNative in hex format
+		buff.Write(common.Hex2Bytes("0000000000000000000000000000000000000000000000000000000000000080")) // offset for ids array
+		buff.Write(common.Hex2Bytes("00000000000000000000000000000000000000000000000000000000000000e0")) // offset for tuple array
+		buff.Write(common.Hex2Bytes("0000000000000000000000000000000000000000000000000000000000000002")) // array length of 2
+		buff.Write(common.Hex2Bytes("0000000000000000000000000000000000000000000000000000000000000012")) // first upkeep id - 18
+		buff.Write(common.Hex2Bytes("0000000000000000000000000000000000000000000000000000000000000017")) // second upkeep id - 23
+		buff.Write(common.Hex2Bytes("0000000000000000000000000000000000000000000000000000000000000002")) // length of array 2
+		buff.Write(common.Hex2Bytes("0000000000000000000000000000000000000000000000000000000000000040")) // tuple 1 offset
+		buff.Write(common.Hex2Bytes("00000000000000000000000000000000000000000000000000000000000000e0")) // tuple 2 offset
+		buff.Write(common.Hex2Bytes("000000000000000000000000000000000000000000000000000000000000002a")) // block number 42
+		buff.Write(common.Hex2Bytes("0100000000000000000000000000000000000000000000000000000000000000")) // block hash 1
+		buff.Write(common.Hex2Bytes("0000000000000000000000000000000000000000000000000000000000000060")) // tuple 1 byte array offset
+		buff.Write(common.Hex2Bytes("0000000000000000000000000000000000000000000000000000000000000005")) // tuple 1 byte length
+		buff.Write(common.Hex2Bytes("68656c6c6f000000000000000000000000000000000000000000000000000000")) // tuple 1 bytes
+		buff.Write(common.Hex2Bytes("000000000000000000000000000000000000000000000000000000000000002b")) // block number 43
+		buff.Write(common.Hex2Bytes("0200000000000000000000000000000000000000000000000000000000000000")) // block hash 2
+		buff.Write(common.Hex2Bytes("0000000000000000000000000000000000000000000000000000000000000060")) // tuple 2 byte array offset
+		buff.Write(common.Hex2Bytes("000000000000000000000000000000000000000000000000000000000000007f")) // tuple 2 byte length
+		buff.Write(common.Hex2Bytes("6c6f6e6720706572666f726d206461746120746861742074616b657320757020")) // tuple 2 bytes
+		buff.Write(common.Hex2Bytes("6d6f7265207468616e20333220627974657320746f2073686f7720686f772062")) // tuple 2 bytes cont...
+		buff.Write(common.Hex2Bytes("79746520617272617973206172652061626920656e636f6465642e2074686973")) // tuple 2 bytes cont...
+		buff.Write(common.Hex2Bytes("2073686f756c642074616b65207570206d756c7469706c6520736c6f74732e00")) // tuple 2 bytes cont...
+
+		expected := buff.Bytes()
+
+		t.Log(common.Bytes2Hex(b))
 
 		assert.NoError(t, err)
 		assert.Equal(t, expected, b)

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -1,9 +1,17 @@
 package ocr2keepers
 
 import (
+	"time"
+
 	"github.com/smartcontractkit/libocr/commontypes"
 	"github.com/smartcontractkit/libocr/offchainreporting2/types"
 	ktypes "github.com/smartcontractkit/ocr2keepers/pkg/types"
+)
+
+const (
+	// DefaultCacheClearInterval is the default setting for the interval at
+	// which the cache attempts to evict expired keys
+	DefaultCacheClearInterval = 30 * time.Second
 )
 
 // DelegateConfig provides a single configuration struct for all options
@@ -25,4 +33,6 @@ type DelegateConfig struct {
 	Registry ktypes.Registry
 	// ReportEncoder is an abstract encoder for encoding reports destined for trasmission; can be evm based or anything else
 	ReportEncoder ktypes.ReportEncoder
+	// ClearCacheInterval is a configural parameter for how often the cache attempts to evict expired keys
+	ClearCacheInterval time.Duration
 }

--- a/pkg/delegate.go
+++ b/pkg/delegate.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"time"
 
 	offchainreporting "github.com/smartcontractkit/libocr/offchainreporting2"
 	"github.com/smartcontractkit/ocr2keepers/internal/keepers"
@@ -25,6 +26,12 @@ func NewDelegate(c DelegateConfig) (*Delegate, error) {
 	wrapper := &logWriter{l: c.Logger}
 	l := log.New(wrapper, "[keepers-plugin] ", log.Lshortfile)
 
+	// set default interval to 30 seconds and override if set in config
+	var clearCacheInterval time.Duration = DefaultCacheClearInterval
+	if c.ClearCacheInterval != 0 {
+		clearCacheInterval = c.ClearCacheInterval
+	}
+
 	keeper, err := offchainreporting.NewOracle(offchainreporting.OracleArgs{
 		BinaryNetworkEndpointFactory: c.BinaryNetworkEndpointFactory,
 		V2Bootstrappers:              c.V2Bootstrappers,
@@ -37,7 +44,7 @@ func NewDelegate(c DelegateConfig) (*Delegate, error) {
 		OffchainConfigDigester:       c.OffchainConfigDigester,
 		OffchainKeyring:              c.OffchainKeyring,
 		OnchainKeyring:               c.OnchainKeyring,
-		ReportingPluginFactory:       keepers.NewReportingPluginFactory(c.Registry, c.ReportEncoder, l),
+		ReportingPluginFactory:       keepers.NewReportingPluginFactory(c.Registry, c.ReportEncoder, l, clearCacheInterval),
 	})
 
 	if err != nil {

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -1,10 +1,14 @@
 package types
 
-import "context"
+import (
+	"context"
+	"math/big"
+)
 
 type Registry interface {
 	GetActiveUpkeepKeys(context.Context, BlockKey) ([]UpkeepKey, error)
 	CheckUpkeep(context.Context, UpkeepKey) (bool, UpkeepResult, error)
+	IdentifierFromKey(UpkeepKey) (UpkeepIdentifier, error)
 }
 
 type ReportEncoder interface {
@@ -15,12 +19,21 @@ type BlockKey string
 
 type Address []byte
 
+// UpkeepKey is an identifier of an upkeep at a moment in time, typically an
+// upkeep at a block number
 type UpkeepKey []byte
 
+// UpkeepIdentifier is an identifier for an active upkeep, typically a big int
+type UpkeepIdentifier []byte
+
 type UpkeepResult struct {
-	Key         UpkeepKey
-	State       UpkeepState
-	PerformData []byte
+	Key              UpkeepKey
+	State            UpkeepState
+	PerformData      []byte
+	FastGasWei       *big.Int
+	LinkNative       *big.Int
+	CheckBlockNumber uint32
+	CheckBlockHash   [32]byte
 }
 
 type UpkeepState uint

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -44,3 +44,15 @@ const (
 	Perform
 	Reported
 )
+
+type OffChainConfig struct {
+	// PerformLockoutWindow is the window in which a single upkeep cannot be
+	// performed again while waiting for a confirmation. Standard setting is
+	// 100 blocks * average block time. Units are in milliseconds
+	PerformLockoutWindow int64 `json:"performLockoutWindow"`
+}
+
+/*
+type onChainConfig struct {
+}
+*/


### PR DESCRIPTION
This PR adds config parameters to the delegate config that get passed to the report plugin factory. These parameters are intended to be node specific and help operators balance computing resources.