### PR TITLE
Refactor InFlight State

### DIFF
--- a/internal/keepers/cache.go
+++ b/internal/keepers/cache.go
@@ -65,6 +65,12 @@ func (c *cache[T]) Get(key string) (T, bool) {
 	return value.Item, true
 }
 
+func (c *cache[T]) Delete(key string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	delete(c.data, key)
+}
+
 // ClearExpired loops through all keys and evaluates the value
 // expire time. If an item is expired, it is removed from the
 // cache. This function places a read lock on the data set and

--- a/pkg/chain/evmregistry_test.go
+++ b/pkg/chain/evmregistry_test.go
@@ -72,7 +72,7 @@ func TestCheckUpkeep(t *testing.T) {
 		ok, upkeep, err := reg.CheckUpkeep(ctx, types.UpkeepKey([]byte("1|1234")))
 		assert.NoError(t, err)
 		assert.Equal(t, true, ok)
-		assert.Equal(t, types.Perform, upkeep.State)
+		assert.Equal(t, types.Eligible, upkeep.State)
 	})
 
 	t.Run("UPKEEP_NOT_NEEDED", func(t *testing.T) {
@@ -98,7 +98,7 @@ func TestCheckUpkeep(t *testing.T) {
 		ok, upkeep, err := reg.CheckUpkeep(ctx, types.UpkeepKey([]byte("1|1234")))
 		assert.NoError(t, err)
 		assert.Equal(t, false, ok)
-		assert.Equal(t, types.Skip, upkeep.State)
+		assert.Equal(t, types.NotEligible, upkeep.State)
 	})
 
 }

--- a/pkg/chain/evmreports.go
+++ b/pkg/chain/evmreports.go
@@ -57,7 +57,7 @@ func (b *evmReportEncoder) EncodeReport(toReport []ktypes.UpkeepResult) ([]byte,
 	data := make([]w, len(toReport))
 
 	for i, result := range toReport {
-		_, upkeepId, err := blockAndIdFromKey(result.Key)
+		_, upkeepId, err := BlockAndIdFromKey(result.Key)
 		if err != nil {
 			return nil, fmt.Errorf("%w: report encoding error", err)
 		}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -23,7 +23,9 @@ type PerformLogProvider interface {
 }
 
 type PerformLog struct {
-	Key UpkeepKey
+	Key           UpkeepKey
+	TransmitBlock BlockKey
+	Confirmations int64
 }
 
 type BlockKey string
@@ -52,10 +54,9 @@ type UpkeepResult struct {
 type UpkeepState uint
 
 const (
-	Eligible UpkeepState = iota
-	Skip
-	Perform
-	Reported
+	NotEligible UpkeepState = iota
+	Eligible
+	InFlight
 	Performed
 )
 


### PR DESCRIPTION
In processing incoming logs, delete items in in-flight state.

When checking upkeeps, return state as in-flight if the key exists.

The registry should return the block number returned from the contract instead of the block number used to check the upkeep. This keeps the cache keys and perform data wrapper in sync.