### PR TITLE
Add Race Detection to Test Coverage

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -29,3 +29,6 @@ jobs:
 
     - name: Test
       run: go test -v ./...
+
+    - name: Race Test
+      run: go test -race ./...

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,9 @@ dependencies:
 test: dependencies
 	@go test -v $(GOPACKAGES)
 
+race: dependencies
+	@go test -race $(GOPACKAGES)
+
 coverage: 
 	@go test -coverprofile cover.out $(GOPACKAGES)
 

--- a/internal/keepers/worker_test.go
+++ b/internal/keepers/worker_test.go
@@ -280,10 +280,13 @@ func TestWorkerGroup(t *testing.T) {
 		}
 
 		// check that queue is closed
-		testAdd := func() {
-			wg.queue <- func(_ context.Context) (int, error) { return 0, nil }
+		testAdd := func() error {
+			return wg.Do(context.Background(), func(ctx context.Context) (int, error) {
+				return 0, nil
+			})
 		}
-		assert.Panics(t, testAdd, "queue should be closed")
+
+		assert.ErrorIs(t, testAdd(), ErrProcessStopped, "queue should be closed")
 	})
 }
 


### PR DESCRIPTION
Using `-race` in tests revealed a potential race condition on the worker group. This condition was corrected and race detection tests have been added to the CI pipeline.