### PR TITLE
Force registry wrapper to respect context

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.18
+        go-version: 1.19
 
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
@@ -32,7 +32,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.18
+        go-version: 1.19
 
     - name: Run Unit Tests
       run: go test -v ./...
@@ -45,7 +45,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.18
+        go-version: 1.19
 
     - name: Run Race Tests
       run: go test -race ./...
@@ -58,7 +58,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.18
+        go-version: 1.19
 
     - name: Run Keepers Package Fuzz Tests
       run: go test --fuzz=Fuzz --fuzztime=10s -run=^# github.com/smartcontractkit/ocr2keepers/internal/keepers

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/smartcontractkit/ocr2keepers
 
-go 1.18
+go 1.19
 
 require (
 	github.com/ethereum/go-ethereum v1.10.25

--- a/internal/keepers/service.go
+++ b/internal/keepers/service.go
@@ -12,6 +12,8 @@ import (
 	"github.com/smartcontractkit/ocr2keepers/pkg/types"
 )
 
+var ErrTooManyErrors = fmt.Errorf("too many errors in parallel worker process")
+
 type onDemandUpkeepService struct {
 	logger       *log.Logger
 	ratio        sampleRatio
@@ -160,6 +162,7 @@ EachKey:
 		// for every job added to the worker queue, add to the wait group
 		// all jobs should complete before completing the function
 		wg.Add(1)
+		s.logger.Printf("attempting to send key to worker group")
 		if err := s.workers.Do(ctx, makeWorkerFunc(s.logger, s.registry, key, ctx)); err != nil {
 			if errors.Is(err, ErrContextCancelled) {
 				// if the context is cancelled before the work can be
@@ -195,7 +198,7 @@ EachKey:
 	// in the case that all workers encounter an error, bubble this up as a hard
 	// failure of the process.
 	if wResults.Total() > 0 && wResults.Total() == wResults.Failures() && wResults.LastErr() != nil {
-		return samples.Values(), fmt.Errorf("%w: too many errors in parallel worker process; last error provided", wResults.LastErr())
+		return samples.Values(), fmt.Errorf("%w: last error encounter by worker was '%s'", ErrTooManyErrors, wResults.LastErr())
 	}
 
 	return samples.Values(), nil
@@ -222,17 +225,17 @@ Outer:
 				r.AddFailure(1)
 			}
 		case <-done:
-			s.logger.Printf("done signal received for worker group")
+			s.logger.Printf("done signal received for job result aggregator")
 			break Outer
 		}
 	}
 }
 
 func makeWorkerFunc(logger *log.Logger, registry types.Registry, key types.UpkeepKey, jobCtx context.Context) func(ctx context.Context) (types.UpkeepResult, error) {
-	return func(ctx context.Context) (types.UpkeepResult, error) {
+	return func(serviceCtx context.Context) (types.UpkeepResult, error) {
 		// cancel the job if either the worker group is stopped (ctx) or the
 		// job context is cancelled (jobCtx)
-		if jobCtx.Err() != nil || ctx.Err() != nil {
+		if jobCtx.Err() != nil || serviceCtx.Err() != nil {
 			return types.UpkeepResult{}, fmt.Errorf("job not attempted because one of two contexts had already been cancelled")
 		}
 
@@ -244,7 +247,7 @@ func makeWorkerFunc(logger *log.Logger, registry types.Registry, key types.Upkee
 			case <-jobCtx.Done():
 				logger.Printf("check upkeep job context cancelled for key %s", key)
 				cancel()
-			case <-ctx.Done():
+			case <-serviceCtx.Done():
 				logger.Printf("worker service context cancelled")
 				cancel()
 			case <-done:

--- a/internal/keepers/service.go
+++ b/internal/keepers/service.go
@@ -232,6 +232,7 @@ Outer:
 }
 
 func makeWorkerFunc(logger *log.Logger, registry types.Registry, key types.UpkeepKey, jobCtx context.Context) func(ctx context.Context) (types.UpkeepResult, error) {
+	logger.Printf("check upkeep job created for key: '%s'", key)
 	return func(serviceCtx context.Context) (types.UpkeepResult, error) {
 		// cancel the job if either the worker group is stopped (ctx) or the
 		// job context is cancelled (jobCtx)
@@ -318,17 +319,21 @@ func (wr *workerResults) SetLastErr(err error) {
 func (wr *workerResults) Total() int {
 	wr.mu.RLock()
 	defer wr.mu.RUnlock()
+	return wr.total()
+}
+
+func (wr *workerResults) total() int {
 	return wr.success + wr.failure
 }
 
 func (wr *workerResults) SuccessRate() float64 {
 	wr.mu.RLock()
 	defer wr.mu.RUnlock()
-	return float64(wr.success) / float64(wr.Total())
+	return float64(wr.success) / float64(wr.total())
 }
 
 func (wr *workerResults) FailureRate() float64 {
 	wr.mu.RLock()
 	defer wr.mu.RUnlock()
-	return float64(wr.failure) / float64(wr.Total())
+	return float64(wr.failure) / float64(wr.total())
 }

--- a/internal/keepers/service_test.go
+++ b/internal/keepers/service_test.go
@@ -163,9 +163,10 @@ func TestOnDemandUpkeepService(t *testing.T) {
 		assert.Greater(t, len(result), 0)
 
 		cancel()
-		<-time.After(10 * time.Millisecond)
+		<-time.After(100 * time.Millisecond)
 
-		scnr := bufio.NewScanner(&logBuff)
+		b := logBuff.Bytes()
+		scnr := bufio.NewScanner(bytes.NewBuffer(b))
 		scnr.Split(bufio.ScanLines)
 
 		var attempted int

--- a/internal/keepers/service_test.go
+++ b/internal/keepers/service_test.go
@@ -1,10 +1,13 @@
 package keepers
 
 import (
+	"bufio"
+	"bytes"
 	"context"
 	"fmt"
 	"io"
 	"log"
+	"strings"
 	"testing"
 	"time"
 
@@ -98,9 +101,11 @@ func TestOnDemandUpkeepService(t *testing.T) {
 	})
 
 	t.Run("SampleUpkeeps_CancelContext", func(t *testing.T) {
+
 		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 		rg := new(MockedRegistry)
 
+		// test with 100 keys which should start up 100 worker jobs
 		keyCount := 100
 		actives := make([]ktypes.UpkeepKey, keyCount)
 		for i := 0; i < keyCount; i++ {
@@ -108,10 +113,12 @@ func TestOnDemandUpkeepService(t *testing.T) {
 			rg.Mock.On("IdentifierFromKey", actives[i]).Return(ktypes.UpkeepIdentifier([]byte(fmt.Sprintf("%d", i+1))), nil).Maybe()
 		}
 
+		// the after func simulates a blocking RPC call that either takes
+		// 90 milliseconds to complete or exits on context cancellation
 		makeAfterFunc := func(ct context.Context) func() chan struct{} {
 			return func() chan struct{} {
 				c := make(chan struct{}, 1)
-				t := time.NewTimer(90 * time.Millisecond)
+				t := time.NewTimer(15 * time.Millisecond)
 
 				go func() {
 					select {
@@ -137,14 +144,15 @@ func TestOnDemandUpkeepService(t *testing.T) {
 				Maybe()
 		}
 
-		l := log.New(io.Discard, "", 0)
+		var logBuff bytes.Buffer
+		l := log.New(&logBuff, "", 0)
 		svc := &onDemandUpkeepService{
 			logger:   l,
 			ratio:    sampleRatio(1.0),
 			registry: rg,
 			shuffler: new(noShuffleShuffler[ktypes.UpkeepKey]),
 			cache:    newCache[ktypes.UpkeepResult](200 * time.Millisecond),
-			workers:  newWorkerGroup[ktypes.UpkeepResult](10, 100),
+			workers:  newWorkerGroup[ktypes.UpkeepResult](10, 20),
 		}
 
 		result, err := svc.SampleUpkeeps(ctx)
@@ -152,10 +160,53 @@ func TestOnDemandUpkeepService(t *testing.T) {
 			t.FailNow()
 		}
 
-		assert.Less(t, len(result), 25)
-		assert.Greater(t, len(result), 4)
+		assert.Greater(t, len(result), 0)
 
 		cancel()
+		<-time.After(10 * time.Millisecond)
+
+		scnr := bufio.NewScanner(&logBuff)
+		scnr.Split(bufio.ScanLines)
+
+		var attempted int
+		var notAttempted int
+		var cancelled int
+		var completed int
+		var notSentToWorker int
+		for scnr.Scan() {
+			line := scnr.Text()
+
+			if strings.Contains(line, "attempting to send") {
+				attempted++
+			}
+
+			//if strings.Contains(line, "upkeep ready to perform") {
+			if strings.Contains(line, "check upkeep took") {
+				completed++
+			}
+
+			if strings.Contains(line, "check upkeep job context cancelled") {
+				cancelled++
+			}
+
+			if strings.Contains(line, "job not attempted") {
+				notAttempted++
+			}
+
+			if strings.Contains(line, "context cancelled while") {
+				notSentToWorker++
+			}
+		}
+
+		t.Logf("jobs attempted: %d", attempted)
+		t.Logf("jobs not attempted: %d", notAttempted)
+		t.Logf("jobs completed: %d", completed)
+		t.Logf("jobs cancelled: %d", cancelled)
+		t.Logf("jobs not sent to worker: %d", notSentToWorker)
+
+		assert.Equal(t, attempted, completed+notAttempted+notSentToWorker)
+		assert.Greater(t, cancelled, 0)
+
 	})
 
 	t.Run("CheckUpkeep", func(t *testing.T) {
@@ -275,7 +326,7 @@ func TestOnDemandUpkeepService(t *testing.T) {
 		// the process should return an error that wraps the last CheckUpkeep
 		// error with context about which key was checked and that too many
 		// errors were encountered during the parallel worker process
-		assert.Contains(t, err.Error(), "too many errors in parallel worker process; last error provided")
+		assert.Contains(t, err.Error(), "too many errors in parallel worker process: last error ")
 	})
 }
 

--- a/internal/keepers/service_test.go
+++ b/internal/keepers/service_test.go
@@ -165,8 +165,14 @@ func TestOnDemandUpkeepService(t *testing.T) {
 		cancel()
 		<-time.After(100 * time.Millisecond)
 
-		b := logBuff.Bytes()
-		scnr := bufio.NewScanner(bytes.NewBuffer(b))
+		pR, pW := io.Pipe()
+
+		go func() {
+			defer pW.Close()
+			io.Copy(pW, &logBuff)
+		}()
+
+		scnr := bufio.NewScanner(pR)
 		scnr.Split(bufio.ScanLines)
 
 		var attempted int

--- a/internal/keepers/service_test.go
+++ b/internal/keepers/service_test.go
@@ -169,7 +169,7 @@ func TestOnDemandUpkeepService(t *testing.T) {
 
 		go func() {
 			defer pW.Close()
-			io.Copy(pW, &logBuff)
+			_, _ = io.Copy(pW, &logBuff)
 		}()
 
 		scnr := bufio.NewScanner(pR)

--- a/pkg/chain/evmregistry_test.go
+++ b/pkg/chain/evmregistry_test.go
@@ -2,8 +2,10 @@ package chain
 
 import (
 	"context"
+	"fmt"
 	"math/big"
 	"testing"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
@@ -124,6 +126,29 @@ func TestCheckUpkeep(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, false, ok)
 		assert.Equal(t, types.NotEligible, upkeep.State)
+	})
+
+	t.Run("Hanging process respects context", func(t *testing.T) {
+		mockClient := new(mocks.Client)
+		ctx := context.Background()
+		ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+
+		rec := mocks.NewContractMockReceiver(t, mockClient, *kabi)
+		rec.MockNonRevertError("checkUpkeep", fmt.Errorf("test error"), 200*time.Millisecond)
+
+		reg, err := NewEVMRegistryV2_0(common.Address{}, mockClient)
+		if err != nil {
+			t.FailNow()
+		}
+
+		start := time.Now()
+		ok, _, err := reg.CheckUpkeep(ctx, types.UpkeepKey([]byte("1|1234")))
+
+		assert.LessOrEqual(t, time.Since(start), 60*time.Millisecond)
+
+		cancel()
+		assert.ErrorIs(t, err, ErrContextCancelled)
+		assert.Equal(t, false, ok)
 	})
 }
 

--- a/pkg/chain/evmregistry_test.go
+++ b/pkg/chain/evmregistry_test.go
@@ -130,7 +130,6 @@ func TestCheckUpkeep(t *testing.T) {
 
 	t.Run("Hanging process respects context", func(t *testing.T) {
 		mockClient := new(mocks.Client)
-		ctx := context.Background()
 		ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
 
 		rec := mocks.NewContractMockReceiver(t, mockClient, *kabi)


### PR DESCRIPTION
The geth wrappers are a bit of a black box and network aborts may not be functioning approapriately for context cancellations. This update forces the wrapper to respect context cancellations with a hard stop to ensure other calling functions are non-blocking.