### PR TITLE
remove default min confirmations

### DIFF
--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -146,10 +146,6 @@ func DecodeOffchainConfig(b []byte) (OffchainConfig, error) {
 		config.SamplingJobDuration = 3000 // default of 3 seconds if not set
 	}
 
-	if config.MinConfirmations == 0 {
-		config.MinConfirmations = 1
-	}
-
 	if config.GasLimitPerReport == 0 {
 		config.GasLimitPerReport = 5_300_000
 	}


### PR DESCRIPTION
0 is a legitimate value of minConfirmations that we may want to have. This piece of code does not allow us to set it as 0