### PR TITLE
Change the UpkeepKey type to an interface

### DIFF
--- a/cmd/simv2/simulators/contract.go
+++ b/cmd/simv2/simulators/contract.go
@@ -28,7 +28,7 @@ type Digester interface {
 }
 
 type ContractTelemetry interface {
-	CheckKey([]byte)
+	CheckKey(ktypes.UpkeepKey)
 }
 
 type RPCTelemetry interface {

--- a/cmd/simv2/simulators/registry.go
+++ b/cmd/simv2/simulators/registry.go
@@ -3,12 +3,12 @@ package simulators
 import (
 	"context"
 	"fmt"
-	"github.com/smartcontractkit/ocr2keepers/pkg/chain"
 	"math/big"
 	"sync"
 
 	"go.uber.org/multierr"
 
+	"github.com/smartcontractkit/ocr2keepers/pkg/chain"
 	"github.com/smartcontractkit/ocr2keepers/pkg/types"
 )
 

--- a/cmd/simv2/simulators/registry.go
+++ b/cmd/simv2/simulators/registry.go
@@ -3,8 +3,8 @@ package simulators
 import (
 	"context"
 	"fmt"
+	"github.com/smartcontractkit/ocr2keepers/pkg/chain"
 	"math/big"
-	"strings"
 	"sync"
 
 	"go.uber.org/multierr"
@@ -28,7 +28,7 @@ func (ct *SimulatedContract) GetActiveUpkeepKeys(ctx context.Context, key types.
 
 	// TODO: filter out cancelled upkeeps
 	for key := range ct.upkeeps {
-		k := types.UpkeepKey([]byte(fmt.Sprintf("%s|%s", block, key)))
+		k := chain.UpkeepKey([]byte(fmt.Sprintf("%s|%s", block, key)))
 		keys = append(keys, k)
 	}
 	ct.mu.RUnlock()
@@ -64,18 +64,18 @@ func (ct *SimulatedContract) CheckUpkeep(ctx context.Context, keys ...types.Upke
 		go func(i int, key types.UpkeepKey) {
 			defer wg.Done()
 
-			parts := strings.Split(string(key), "|")
-			if len(parts) != 2 {
-				panic("upkeep key does not contain block and id")
+			blockKey, upkeepID, err := key.BlockKeyAndUpkeepID()
+			if err != nil {
+				panic(err.Error())
 			}
 
-			block, ok := new(big.Int).SetString(parts[0], 10)
+			block, ok := new(big.Int).SetString(string(blockKey), 10)
 			if !ok {
 				mErr = multierr.Append(mErr, fmt.Errorf("block in key not parsable as big int"))
 				return
 			}
 
-			up, ok := ct.upkeeps[parts[1]]
+			up, ok := ct.upkeeps[string(upkeepID)]
 			if !ok {
 				mErr = multierr.Append(mErr, fmt.Errorf("upkeep not registered"))
 				return
@@ -150,10 +150,9 @@ func (ct *SimulatedContract) CheckUpkeep(ctx context.Context, keys ...types.Upke
 }
 
 func (ct *SimulatedContract) IdentifierFromKey(key types.UpkeepKey) (types.UpkeepIdentifier, error) {
-	parts := strings.Split(string(key), "|")
-	if len(parts) != 2 {
-		panic("upkeep key does not contain block and id")
+	_, upkeepID, err := key.BlockKeyAndUpkeepID()
+	if err != nil {
+		panic(err.Error())
 	}
-
-	return types.UpkeepIdentifier(parts[1]), nil
+	return upkeepID, nil
 }

--- a/cmd/simv2/simulators/registry_test.go
+++ b/cmd/simv2/simulators/registry_test.go
@@ -2,11 +2,11 @@ package simulators
 
 import (
 	"context"
-	"github.com/smartcontractkit/ocr2keepers/pkg/chain"
 	"math/big"
 	"testing"
 	"time"
 
+	"github.com/smartcontractkit/ocr2keepers/pkg/chain"
 	"github.com/smartcontractkit/ocr2keepers/pkg/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"

--- a/cmd/simv2/simulators/registry_test.go
+++ b/cmd/simv2/simulators/registry_test.go
@@ -2,6 +2,7 @@ package simulators
 
 import (
 	"context"
+	"github.com/smartcontractkit/ocr2keepers/pkg/chain"
 	"math/big"
 	"testing"
 	"time"
@@ -28,7 +29,7 @@ func TestCheckUpkeep(t *testing.T) {
 				},
 				Performs: map[string]types.PerformLog{
 					"7": {
-						Key: types.UpkeepKey([]byte("4|20")),
+						Key: chain.UpkeepKey([]byte("4|20")),
 					},
 				},
 			},
@@ -44,7 +45,7 @@ func TestCheckUpkeep(t *testing.T) {
 
 	mct.On("CheckKey", mock.Anything)
 
-	checkKey := types.UpkeepKey([]byte("8|201"))
+	checkKey := chain.UpkeepKey([]byte("8|201"))
 	res, err := contract.CheckUpkeep(context.Background(), checkKey)
 	assert.NoError(t, err)
 	assert.Len(t, res, 1)
@@ -52,7 +53,7 @@ func TestCheckUpkeep(t *testing.T) {
 	assert.Equal(t, types.NotEligible, res[0].State)
 
 	tel.On("RegisterCall", "checkUpkeep", mock.Anything, nil)
-	checkKey2 := types.UpkeepKey([]byte("11|201"))
+	checkKey2 := chain.UpkeepKey([]byte("11|201"))
 	res, err = contract.CheckUpkeep(context.Background(), checkKey2)
 	assert.NoError(t, err)
 	assert.Len(t, res, 1)
@@ -76,6 +77,6 @@ type MockContractTelemetry struct {
 	mock.Mock
 }
 
-func (_m *MockContractTelemetry) CheckKey(key []byte) {
+func (_m *MockContractTelemetry) CheckKey(key types.UpkeepKey) {
 	_m.Mock.Called(key)
 }

--- a/cmd/simv2/stats.go
+++ b/cmd/simv2/stats.go
@@ -2,13 +2,11 @@ package main
 
 import (
 	"fmt"
-	"math/big"
-	"sort"
-	"strings"
-
 	"github.com/smartcontractkit/ocr2keepers/cmd/simv2/blocks"
 	"github.com/smartcontractkit/ocr2keepers/cmd/simv2/simulators"
 	"github.com/smartcontractkit/ocr2keepers/pkg/types"
+	"math/big"
+	"sort"
 )
 
 type upkeepStatsBuilder struct {
@@ -54,9 +52,9 @@ func newUpkeepStatsBuilder(
 
 		// tr.SendingAddress
 		for _, trResult := range reported {
-			parts := strings.Split(string(trResult.Key), "|")
-			performsByID[parts[1]] = append(performsByID[parts[1]], block.String())
-			trsByID[parts[1]] = append(trsByID[parts[1]], tr)
+			_, upkeepID, _ := trResult.Key.BlockKeyAndUpkeepID()
+			performsByID[string(upkeepID)] = append(performsByID[string(upkeepID)], block.String())
+			trsByID[string(upkeepID)] = append(trsByID[string(upkeepID)], tr)
 		}
 	}
 

--- a/cmd/simv2/telemetry/contract.go
+++ b/cmd/simv2/telemetry/contract.go
@@ -1,8 +1,8 @@
 package telemetry
 
 import (
+	"github.com/smartcontractkit/ocr2keepers/pkg/types"
 	"io"
-	"strings"
 	"sync"
 )
 
@@ -92,12 +92,13 @@ type WrappedContractCollector struct {
 	keyIDLookup map[string][]string
 }
 
-func (wc *WrappedContractCollector) CheckKey(key []byte) {
+func (wc *WrappedContractCollector) CheckKey(key types.UpkeepKey) {
 	wc.mu.Lock()
 	defer wc.mu.Unlock()
 
-	k := string(key)
-	parts := strings.Split(k, "|")
+	k := key.String()
+
+	blockKey, upkeepID, _ := key.BlockKeyAndUpkeepID()
 
 	_, ok := wc.keyChecks[k]
 	if !ok {
@@ -105,19 +106,19 @@ func (wc *WrappedContractCollector) CheckKey(key []byte) {
 	}
 	wc.keyChecks[k]++
 
-	val, ok := wc.keyIDLookup[parts[1]]
+	val, ok := wc.keyIDLookup[string(upkeepID)]
 	if !ok {
-		wc.keyIDLookup[parts[1]] = []string{parts[0]}
+		wc.keyIDLookup[string(upkeepID)] = []string{string(blockKey)}
 	} else {
 		var found bool
 		for _, v := range val {
-			if v == parts[0] {
+			if v == string(blockKey) {
 				found = true
 			}
 		}
 
 		if !found {
-			wc.keyIDLookup[parts[1]] = append(val, parts[0])
+			wc.keyIDLookup[string(upkeepID)] = append(val, string(blockKey))
 		}
 	}
 }

--- a/cmd/simv2/telemetry/contract.go
+++ b/cmd/simv2/telemetry/contract.go
@@ -1,9 +1,10 @@
 package telemetry
 
 import (
-	"github.com/smartcontractkit/ocr2keepers/pkg/types"
 	"io"
 	"sync"
+
+	"github.com/smartcontractkit/ocr2keepers/pkg/types"
 )
 
 type ContractEventCollector struct {

--- a/internal/keepers/encode_test.go
+++ b/internal/keepers/encode_test.go
@@ -1,9 +1,9 @@
 package keepers
 
 import (
-	"github.com/smartcontractkit/ocr2keepers/pkg/chain"
 	"testing"
 
+	"github.com/smartcontractkit/ocr2keepers/pkg/chain"
 	ktypes "github.com/smartcontractkit/ocr2keepers/pkg/types"
 )
 

--- a/internal/keepers/encode_test.go
+++ b/internal/keepers/encode_test.go
@@ -1,15 +1,16 @@
 package keepers
 
 import (
+	"github.com/smartcontractkit/ocr2keepers/pkg/chain"
 	"testing"
 
 	ktypes "github.com/smartcontractkit/ocr2keepers/pkg/types"
 )
 
 func BenchmarkDecode(b *testing.B) {
-	key1 := ktypes.UpkeepKey([]byte("1239487928374|18768923479234987"))
-	key2 := ktypes.UpkeepKey([]byte("1239487928374|18768923479234989"))
-	key3 := ktypes.UpkeepKey([]byte("1239487928375|18768923479234987"))
+	key1 := chain.UpkeepKey([]byte("1239487928374|18768923479234987"))
+	key2 := chain.UpkeepKey([]byte("1239487928374|18768923479234989"))
+	key3 := chain.UpkeepKey([]byte("1239487928375|18768923479234987"))
 
 	encoded := mustEncodeKeys([]ktypes.UpkeepKey{key1, key2, key3})
 

--- a/internal/keepers/filter_test.go
+++ b/internal/keepers/filter_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/smartcontractkit/ocr2keepers/pkg/chain"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
@@ -29,10 +31,10 @@ func TestReportCoordinator(t *testing.T) {
 	}
 
 	// set up the mocks and mock data
-	key1Block1 := types.UpkeepKey("1|1")
-	key1Block2 := types.UpkeepKey("2|1")
-	key1Block3 := types.UpkeepKey("3|1")
-	key1Block4 := types.UpkeepKey("4|1")
+	key1Block1 := chain.UpkeepKey("1|1")
+	key1Block2 := chain.UpkeepKey("2|1")
+	key1Block3 := chain.UpkeepKey("3|1")
+	key1Block4 := chain.UpkeepKey("4|1")
 	id1 := types.UpkeepIdentifier("1")
 	bk2 := types.BlockKey("2")
 	bk3 := types.BlockKey("3")
@@ -255,5 +257,5 @@ func TestReportCoordinator(t *testing.T) {
 
 func assertFilter(t *testing.T, reg *types.MockRegistry, key types.UpkeepKey, id types.UpkeepIdentifier, exp bool, f func(types.UpkeepKey) bool) {
 	reg.Mock.On("IdentifierFromKey", key).Return(id, nil)
-	assert.Equal(t, exp, f(key), "filter should return '%v' to indicate key should not be filtered out at block %s", exp, string(key))
+	assert.Equal(t, exp, f(key), "filter should return '%v' to indicate key should not be filtered out at block %s", exp, key)
 }

--- a/internal/keepers/filter_test.go
+++ b/internal/keepers/filter_test.go
@@ -6,12 +6,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/smartcontractkit/ocr2keepers/pkg/chain"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
 	"github.com/smartcontractkit/ocr2keepers/internal/util"
+	"github.com/smartcontractkit/ocr2keepers/pkg/chain"
 	"github.com/smartcontractkit/ocr2keepers/pkg/types"
 )
 

--- a/internal/keepers/ocr.go
+++ b/internal/keepers/ocr.go
@@ -227,7 +227,7 @@ func (k *keepers) ShouldTransmitAcceptedReport(_ context.Context, rt types.Repor
 		// (while others may not have), don't try to transmit again
 		// TODO: reevaluate this assumption
 		if transmitConfirmed {
-			k.logger.Printf("not transmitting report because upkeep '%s' was already transmitted: %s", string(id.Key), lCtx)
+			k.logger.Printf("not transmitting report because upkeep '%s' was already transmitted: %s", id.Key, lCtx)
 			return false, nil
 		}
 

--- a/internal/keepers/ocr_test.go
+++ b/internal/keepers/ocr_test.go
@@ -3,16 +3,16 @@ package keepers
 import (
 	"context"
 	"fmt"
+	"github.com/smartcontractkit/ocr2keepers/pkg/chain"
 	"io"
 	"log"
 	"testing"
 	"time"
 
 	"github.com/smartcontractkit/libocr/offchainreporting2/types"
+	ktypes "github.com/smartcontractkit/ocr2keepers/pkg/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-
-	ktypes "github.com/smartcontractkit/ocr2keepers/pkg/types"
 )
 
 func TestQuery(t *testing.T) {
@@ -72,8 +72,8 @@ func TestObservation(t *testing.T) {
 			Name: "Filter to Empty Set",
 			Ctx:  func() (context.Context, func()) { return context.Background(), func() {} },
 			SampleSet: ktypes.UpkeepResults{
-				{Key: ktypes.UpkeepKey("1|1"), State: ktypes.NotEligible},
-				{Key: ktypes.UpkeepKey("1|2"), State: ktypes.NotEligible},
+				{Key: chain.UpkeepKey("1|1"), State: ktypes.NotEligible},
+				{Key: chain.UpkeepKey("1|2"), State: ktypes.NotEligible},
 			},
 			ExpectedObservation: types.Observation(mustEncodeKeys([]ktypes.UpkeepKey{})),
 		},
@@ -81,34 +81,34 @@ func TestObservation(t *testing.T) {
 			Name: "Filter to Non-empty Set",
 			Ctx:  func() (context.Context, func()) { return context.Background(), func() {} },
 			SampleSet: ktypes.UpkeepResults{
-				{Key: ktypes.UpkeepKey([]byte("1|1")), State: ktypes.NotEligible},
-				{Key: ktypes.UpkeepKey([]byte("1|2")), State: ktypes.Eligible},
+				{Key: chain.UpkeepKey([]byte("1|1")), State: ktypes.NotEligible},
+				{Key: chain.UpkeepKey([]byte("1|2")), State: ktypes.Eligible},
 			},
-			ExpectedObservation: types.Observation(mustEncodeKeys([]ktypes.UpkeepKey{[]byte("1|2")})),
+			ExpectedObservation: types.Observation(mustEncodeKeys([]ktypes.UpkeepKey{chain.UpkeepKey("1|2")})),
 		},
 		{
 			Name: "Reduce Key List to Observation Limit",
 			Ctx:  func() (context.Context, func()) { return context.Background(), func() {} },
 			SampleSet: ktypes.UpkeepResults{
-				{Key: ktypes.UpkeepKey([]byte("100000000000100000000000100000000000100000000000100000000001|100000000000100000000000100000000000100000000001")), State: ktypes.Eligible},
-				{Key: ktypes.UpkeepKey([]byte("100000000000100000000000100000000000100000000000100000000001|100000000000100000000000100000000000100000000002")), State: ktypes.Eligible},
-				{Key: ktypes.UpkeepKey([]byte("100000000000100000000000100000000000100000000000100000000001|100000000000100000000000100000000000100000000003")), State: ktypes.Eligible},
-				{Key: ktypes.UpkeepKey([]byte("100000000000100000000000100000000000100000000000100000000001|100000000000100000000000100000000000100000000004")), State: ktypes.Eligible},
-				{Key: ktypes.UpkeepKey([]byte("100000000000100000000000100000000000100000000000100000000001|100000000000100000000000100000000000100000000005")), State: ktypes.Eligible},
-				{Key: ktypes.UpkeepKey([]byte("100000000000100000000000100000000000100000000000100000000001|100000000000100000000000100000000000100000000006")), State: ktypes.Eligible},
-				{Key: ktypes.UpkeepKey([]byte("100000000000100000000000100000000000100000000000100000000001|100000000000100000000000100000000000100000000007")), State: ktypes.Eligible},
-				{Key: ktypes.UpkeepKey([]byte("100000000000100000000000100000000000100000000000100000000001|100000000000100000000000100000000000100000000008")), State: ktypes.Eligible},
-				{Key: ktypes.UpkeepKey([]byte("100000000000100000000000100000000000100000000000100000000001|100000000000100000000000100000000000100000000009")), State: ktypes.Eligible},
-				{Key: ktypes.UpkeepKey([]byte("100000000000100000000000100000000000100000000000100000000001|100000000000100000000000100000000000100000000010")), State: ktypes.Eligible},
-				{Key: ktypes.UpkeepKey([]byte("100000000000100000000000100000000000100000000000100000000001|100000000000100000000000100000000000100000000011")), State: ktypes.Eligible},
+				{Key: chain.UpkeepKey([]byte("100000000000100000000000100000000000100000000000100000000001|100000000000100000000000100000000000100000000001")), State: ktypes.Eligible},
+				{Key: chain.UpkeepKey([]byte("100000000000100000000000100000000000100000000000100000000001|100000000000100000000000100000000000100000000002")), State: ktypes.Eligible},
+				{Key: chain.UpkeepKey([]byte("100000000000100000000000100000000000100000000000100000000001|100000000000100000000000100000000000100000000003")), State: ktypes.Eligible},
+				{Key: chain.UpkeepKey([]byte("100000000000100000000000100000000000100000000000100000000001|100000000000100000000000100000000000100000000004")), State: ktypes.Eligible},
+				{Key: chain.UpkeepKey([]byte("100000000000100000000000100000000000100000000000100000000001|100000000000100000000000100000000000100000000005")), State: ktypes.Eligible},
+				{Key: chain.UpkeepKey([]byte("100000000000100000000000100000000000100000000000100000000001|100000000000100000000000100000000000100000000006")), State: ktypes.Eligible},
+				{Key: chain.UpkeepKey([]byte("100000000000100000000000100000000000100000000000100000000001|100000000000100000000000100000000000100000000007")), State: ktypes.Eligible},
+				{Key: chain.UpkeepKey([]byte("100000000000100000000000100000000000100000000000100000000001|100000000000100000000000100000000000100000000008")), State: ktypes.Eligible},
+				{Key: chain.UpkeepKey([]byte("100000000000100000000000100000000000100000000000100000000001|100000000000100000000000100000000000100000000009")), State: ktypes.Eligible},
+				{Key: chain.UpkeepKey([]byte("100000000000100000000000100000000000100000000000100000000001|100000000000100000000000100000000000100000000010")), State: ktypes.Eligible},
+				{Key: chain.UpkeepKey([]byte("100000000000100000000000100000000000100000000000100000000001|100000000000100000000000100000000000100000000011")), State: ktypes.Eligible},
 			},
 			ExpectedObservation: types.Observation(mustEncodeKeys([]ktypes.UpkeepKey{
-				[]byte("100000000000100000000000100000000000100000000000100000000001|100000000000100000000000100000000000100000000001"),
-				[]byte("100000000000100000000000100000000000100000000000100000000001|100000000000100000000000100000000000100000000002"),
-				[]byte("100000000000100000000000100000000000100000000000100000000001|100000000000100000000000100000000000100000000003"),
-				[]byte("100000000000100000000000100000000000100000000000100000000001|100000000000100000000000100000000000100000000004"),
-				[]byte("100000000000100000000000100000000000100000000000100000000001|100000000000100000000000100000000000100000000005"),
-				[]byte("100000000000100000000000100000000000100000000000100000000001|100000000000100000000000100000000000100000000006"),
+				chain.UpkeepKey([]byte("100000000000100000000000100000000000100000000000100000000001|100000000000100000000000100000000000100000000001")),
+				chain.UpkeepKey([]byte("100000000000100000000000100000000000100000000000100000000001|100000000000100000000000100000000000100000000002")),
+				chain.UpkeepKey([]byte("100000000000100000000000100000000000100000000000100000000001|100000000000100000000000100000000000100000000003")),
+				chain.UpkeepKey([]byte("100000000000100000000000100000000000100000000000100000000001|100000000000100000000000100000000000100000000004")),
+				chain.UpkeepKey([]byte("100000000000100000000000100000000000100000000000100000000001|100000000000100000000000100000000000100000000005")),
+				chain.UpkeepKey([]byte("100000000000100000000000100000000000100000000000100000000001|100000000000100000000000100000000000100000000006")),
 			})),
 		},
 	}
@@ -160,11 +160,11 @@ func BenchmarkObservation(b *testing.B) {
 	}
 
 	set := make(ktypes.UpkeepResults, 2, 100)
-	set[0] = ktypes.UpkeepResult{Key: ktypes.UpkeepKey("1|1"), State: ktypes.Eligible}
-	set[1] = ktypes.UpkeepResult{Key: ktypes.UpkeepKey("1|2"), State: ktypes.Eligible}
+	set[0] = ktypes.UpkeepResult{Key: chain.UpkeepKey("1|1"), State: ktypes.Eligible}
+	set[1] = ktypes.UpkeepResult{Key: chain.UpkeepKey("1|2"), State: ktypes.Eligible}
 
 	for i := 2; i < 100; i++ {
-		set = append(set, ktypes.UpkeepResult{Key: ktypes.UpkeepKey(fmt.Sprintf("1|%d", i+1)), State: ktypes.NotEligible})
+		set = append(set, ktypes.UpkeepResult{Key: chain.UpkeepKey(fmt.Sprintf("1|%d", i+1)), State: ktypes.NotEligible})
 	}
 
 	b.ResetTimer()
@@ -210,16 +210,16 @@ func TestReport(t *testing.T) {
 			ReportGasLimit: 10000000,
 			Ctx:            func() (context.Context, func()) { return context.Background(), func() {} },
 			Observations: []types.AttributedObservation{
-				{Observation: types.Observation(mustEncodeKeys([]ktypes.UpkeepKey{ktypes.UpkeepKey("1|1")}))},
-				{Observation: types.Observation(mustEncodeKeys([]ktypes.UpkeepKey{ktypes.UpkeepKey("1|1")}))},
-				{Observation: types.Observation(mustEncodeKeys([]ktypes.UpkeepKey{ktypes.UpkeepKey("1|1")}))},
+				{Observation: types.Observation(mustEncodeKeys([]ktypes.UpkeepKey{chain.UpkeepKey("1|1")}))},
+				{Observation: types.Observation(mustEncodeKeys([]ktypes.UpkeepKey{chain.UpkeepKey("1|1")}))},
+				{Observation: types.Observation(mustEncodeKeys([]ktypes.UpkeepKey{chain.UpkeepKey("1|1")}))},
 			},
 			Checks: checks{
 				K: []ktypes.UpkeepKey{
-					ktypes.UpkeepKey("1|1"),
+					chain.UpkeepKey("1|1"),
 				},
 				R: ktypes.UpkeepResults{
-					{Key: ktypes.UpkeepKey("1|1"), State: ktypes.Eligible, PerformData: []byte("abcd")},
+					{Key: chain.UpkeepKey("1|1"), State: ktypes.Eligible, PerformData: []byte("abcd")},
 				},
 			},
 			Perform:        []int{0},
@@ -231,16 +231,16 @@ func TestReport(t *testing.T) {
 			ReportGasLimit: 10000000,
 			Ctx:            func() (context.Context, func()) { return context.WithTimeout(context.Background(), time.Second) },
 			Observations: []types.AttributedObservation{
-				{Observation: types.Observation(mustEncodeKeys([]ktypes.UpkeepKey{ktypes.UpkeepKey("1|1")}))},
-				{Observation: types.Observation(mustEncodeKeys([]ktypes.UpkeepKey{ktypes.UpkeepKey("1|1")}))},
-				{Observation: types.Observation(mustEncodeKeys([]ktypes.UpkeepKey{ktypes.UpkeepKey("1|1")}))},
+				{Observation: types.Observation(mustEncodeKeys([]ktypes.UpkeepKey{chain.UpkeepKey("1|1")}))},
+				{Observation: types.Observation(mustEncodeKeys([]ktypes.UpkeepKey{chain.UpkeepKey("1|1")}))},
+				{Observation: types.Observation(mustEncodeKeys([]ktypes.UpkeepKey{chain.UpkeepKey("1|1")}))},
 			},
 			Checks: checks{
 				K: []ktypes.UpkeepKey{
-					ktypes.UpkeepKey("1|1"),
+					chain.UpkeepKey("1|1"),
 				},
 				R: ktypes.UpkeepResults{
-					{Key: ktypes.UpkeepKey("1|1"), State: ktypes.Eligible, PerformData: []byte("abcd")},
+					{Key: chain.UpkeepKey("1|1"), State: ktypes.Eligible, PerformData: []byte("abcd")},
 				},
 			},
 			Perform:        []int{0},
@@ -252,12 +252,12 @@ func TestReport(t *testing.T) {
 			ReportGasLimit: 10000000,
 			Ctx:            func() (context.Context, func()) { return context.WithTimeout(context.Background(), time.Second) },
 			Observations: []types.AttributedObservation{
-				{Observation: types.Observation(mustEncodeKeys([]ktypes.UpkeepKey{ktypes.UpkeepKey("1|1")}))},
-				{Observation: types.Observation(mustEncodeKeys([]ktypes.UpkeepKey{ktypes.UpkeepKey("1|1")}))},
-				{Observation: types.Observation(mustEncodeKeys([]ktypes.UpkeepKey{ktypes.UpkeepKey("1|1")}))},
+				{Observation: types.Observation(mustEncodeKeys([]ktypes.UpkeepKey{chain.UpkeepKey("1|1")}))},
+				{Observation: types.Observation(mustEncodeKeys([]ktypes.UpkeepKey{chain.UpkeepKey("1|1")}))},
+				{Observation: types.Observation(mustEncodeKeys([]ktypes.UpkeepKey{chain.UpkeepKey("1|1")}))},
 			},
 			Checks: checks{
-				K: []ktypes.UpkeepKey{ktypes.UpkeepKey("1|1")},
+				K: []ktypes.UpkeepKey{chain.UpkeepKey("1|1")},
 				R: ktypes.UpkeepResults{{}},
 				E: ErrMockTestError,
 			},
@@ -270,23 +270,23 @@ func TestReport(t *testing.T) {
 			ReportGasLimit: 10000000,
 			Ctx:            func() (context.Context, func()) { return context.Background(), func() {} },
 			Observations: []types.AttributedObservation{
-				{Observation: types.Observation(mustEncodeKeys([]ktypes.UpkeepKey{ktypes.UpkeepKey("1|1")}))},
-				{Observation: types.Observation(mustEncodeKeys([]ktypes.UpkeepKey{ktypes.UpkeepKey("1|2"), ktypes.UpkeepKey("1|1")}))},
-				{Observation: types.Observation(mustEncodeKeys([]ktypes.UpkeepKey{ktypes.UpkeepKey("1|1")}))},
+				{Observation: types.Observation(mustEncodeKeys([]ktypes.UpkeepKey{chain.UpkeepKey("1|1")}))},
+				{Observation: types.Observation(mustEncodeKeys([]ktypes.UpkeepKey{chain.UpkeepKey("1|2"), chain.UpkeepKey("1|1")}))},
+				{Observation: types.Observation(mustEncodeKeys([]ktypes.UpkeepKey{chain.UpkeepKey("1|1")}))},
 			},
 			Checks: checks{
 				K: []ktypes.UpkeepKey{
-					ktypes.UpkeepKey("1|1"),
-					ktypes.UpkeepKey("1|2"),
+					chain.UpkeepKey("1|1"),
+					chain.UpkeepKey("1|2"),
 				},
 				R: ktypes.UpkeepResults{
 					{
-						Key:         ktypes.UpkeepKey("1|1"),
+						Key:         chain.UpkeepKey("1|1"),
 						State:       ktypes.Eligible,
 						PerformData: []byte("abcd"),
 					},
 					{
-						Key:         ktypes.UpkeepKey("1|2"),
+						Key:         chain.UpkeepKey("1|2"),
 						State:       ktypes.NotEligible,
 						PerformData: []byte("abcd"),
 					},
@@ -302,19 +302,19 @@ func TestReport(t *testing.T) {
 			ReportGasLimit: 10000000,
 			Ctx:            func() (context.Context, func()) { return context.Background(), func() {} },
 			Observations: []types.AttributedObservation{
-				{Observation: types.Observation(mustEncodeKeys([]ktypes.UpkeepKey{ktypes.UpkeepKey([]byte("1|2"))}))},
-				{Observation: types.Observation(mustEncodeKeys([]ktypes.UpkeepKey{ktypes.UpkeepKey([]byte("1|1")), ktypes.UpkeepKey([]byte("1|2"))}))},
-				{Observation: types.Observation(mustEncodeKeys([]ktypes.UpkeepKey{ktypes.UpkeepKey([]byte("1|2"))}))},
+				{Observation: types.Observation(mustEncodeKeys([]ktypes.UpkeepKey{chain.UpkeepKey([]byte("1|2"))}))},
+				{Observation: types.Observation(mustEncodeKeys([]ktypes.UpkeepKey{chain.UpkeepKey([]byte("1|1")), chain.UpkeepKey([]byte("1|2"))}))},
+				{Observation: types.Observation(mustEncodeKeys([]ktypes.UpkeepKey{chain.UpkeepKey([]byte("1|2"))}))},
 			},
 			FilterOut: []ktypes.UpkeepKey{
-				ktypes.UpkeepKey("1|1"),
+				chain.UpkeepKey("1|1"),
 			},
 			Checks: checks{
 				K: []ktypes.UpkeepKey{
-					ktypes.UpkeepKey("1|2"),
+					chain.UpkeepKey("1|2"),
 				},
 				R: ktypes.UpkeepResults{
-					{Key: ktypes.UpkeepKey("1|2"), State: ktypes.Eligible, PerformData: []byte("abcd")},
+					{Key: chain.UpkeepKey("1|2"), State: ktypes.Eligible, PerformData: []byte("abcd")},
 				},
 			},
 			Perform:        []int{0},
@@ -326,18 +326,18 @@ func TestReport(t *testing.T) {
 			ReportGasLimit: 10000000,
 			Ctx:            func() (context.Context, func()) { return context.Background(), func() {} },
 			Observations: []types.AttributedObservation{
-				{Observation: types.Observation(mustEncodeKeys([]ktypes.UpkeepKey{ktypes.UpkeepKey("1|2")}))},
-				{Observation: types.Observation(mustEncodeKeys([]ktypes.UpkeepKey{ktypes.UpkeepKey("1|1"), ktypes.UpkeepKey("1|2")}))},
-				{Observation: types.Observation(mustEncodeKeys([]ktypes.UpkeepKey{ktypes.UpkeepKey("1|2")}))},
+				{Observation: types.Observation(mustEncodeKeys([]ktypes.UpkeepKey{chain.UpkeepKey("1|2")}))},
+				{Observation: types.Observation(mustEncodeKeys([]ktypes.UpkeepKey{chain.UpkeepKey("1|1"), chain.UpkeepKey("1|2")}))},
+				{Observation: types.Observation(mustEncodeKeys([]ktypes.UpkeepKey{chain.UpkeepKey("1|2")}))},
 			},
 			Checks: checks{
 				K: []ktypes.UpkeepKey{
-					ktypes.UpkeepKey("1|2"),
-					ktypes.UpkeepKey("1|1"),
+					chain.UpkeepKey("1|2"),
+					chain.UpkeepKey("1|1"),
 				},
 				R: ktypes.UpkeepResults{
-					{Key: ktypes.UpkeepKey("1|2"), State: ktypes.NotEligible, PerformData: []byte("abcd")},
-					{Key: ktypes.UpkeepKey("1|1"), State: ktypes.NotEligible, PerformData: []byte("abcd")},
+					{Key: chain.UpkeepKey("1|2"), State: ktypes.NotEligible, PerformData: []byte("abcd")},
+					{Key: chain.UpkeepKey("1|1"), State: ktypes.NotEligible, PerformData: []byte("abcd")},
 				},
 			},
 			ExpectedBool: false,
@@ -370,16 +370,16 @@ func TestReport(t *testing.T) {
 			ReportGasLimit: 10000000,
 			Ctx:            func() (context.Context, func()) { return context.Background(), func() {} },
 			Observations: []types.AttributedObservation{
-				{Observation: types.Observation(mustEncodeKeys([]ktypes.UpkeepKey{ktypes.UpkeepKey([]byte("1|1"))}))},
-				{Observation: types.Observation(mustEncodeKeys([]ktypes.UpkeepKey{ktypes.UpkeepKey([]byte("1|1"))}))},
-				{Observation: types.Observation(mustEncodeKeys([]ktypes.UpkeepKey{ktypes.UpkeepKey([]byte("1|1"))}))},
+				{Observation: types.Observation(mustEncodeKeys([]ktypes.UpkeepKey{chain.UpkeepKey([]byte("1|1"))}))},
+				{Observation: types.Observation(mustEncodeKeys([]ktypes.UpkeepKey{chain.UpkeepKey([]byte("1|1"))}))},
+				{Observation: types.Observation(mustEncodeKeys([]ktypes.UpkeepKey{chain.UpkeepKey([]byte("1|1"))}))},
 			},
 			Checks: checks{
 				K: []ktypes.UpkeepKey{
-					ktypes.UpkeepKey("1|1"),
+					chain.UpkeepKey("1|1"),
 				},
 				R: ktypes.UpkeepResults{
-					{Key: ktypes.UpkeepKey("1|1"), State: ktypes.Eligible, PerformData: []byte("abcd")},
+					{Key: chain.UpkeepKey("1|1"), State: ktypes.Eligible, PerformData: []byte("abcd")},
 				},
 			},
 			Perform:      []int{0},
@@ -406,7 +406,7 @@ func TestReport(t *testing.T) {
 
 			mf.Mock.On("Filter").Return(func(k ktypes.UpkeepKey) bool {
 				for _, key := range test.FilterOut {
-					if string(k) == string(key) {
+					if k.String() == key.String() {
 						return false
 					}
 				}
@@ -460,9 +460,9 @@ func BenchmarkReport(b *testing.B) {
 		filter:  mf,
 	}
 
-	key1 := ktypes.UpkeepKey([]byte("1|1"))
-	key2 := ktypes.UpkeepKey([]byte("1|2"))
-	key3 := ktypes.UpkeepKey([]byte("2|1"))
+	key1 := chain.UpkeepKey([]byte("1|1"))
+	key2 := chain.UpkeepKey([]byte("1|2"))
+	key3 := chain.UpkeepKey([]byte("2|1"))
 	data := []byte("abcd")
 
 	encoded := mustEncodeKeys([]ktypes.UpkeepKey{key1, key2})
@@ -548,14 +548,14 @@ func TestShouldAcceptFinalizedReport(t *testing.T) {
 			Description: "Should not accept report if calls were previously accepted",
 			ReportContents: []ktypes.UpkeepResult{
 				{
-					Key: ktypes.UpkeepKey("1|1"),
+					Key: chain.UpkeepKey("1|1"),
 				},
 			},
 			AlreadyAccepted: []struct {
 				K ktypes.UpkeepKey
 				B bool
 			}{
-				{K: ktypes.UpkeepKey("1|1"), B: true},
+				{K: chain.UpkeepKey("1|1"), B: true},
 			},
 			ExpectedBool: false,
 			Err:          fmt.Errorf("failed to accept key"),
@@ -565,18 +565,18 @@ func TestShouldAcceptFinalizedReport(t *testing.T) {
 			Description: "Should not accept report if calls were previously accepted",
 			ReportContents: []ktypes.UpkeepResult{
 				{
-					Key: ktypes.UpkeepKey("1|1"),
+					Key: chain.UpkeepKey("1|1"),
 				},
 				{
-					Key: ktypes.UpkeepKey("1|2"),
+					Key: chain.UpkeepKey("1|2"),
 				},
 			},
 			AlreadyAccepted: []struct {
 				K ktypes.UpkeepKey
 				B bool
 			}{
-				{K: ktypes.UpkeepKey("1|1"), B: false},
-				{K: ktypes.UpkeepKey("1|2"), B: true},
+				{K: chain.UpkeepKey("1|1"), B: false},
+				{K: chain.UpkeepKey("1|2"), B: true},
 			},
 			ExpectedBool: false,
 			Err:          fmt.Errorf("failed to accept key"),
@@ -586,18 +586,18 @@ func TestShouldAcceptFinalizedReport(t *testing.T) {
 			Description: "Should not accept report if calls were previously accepted",
 			ReportContents: []ktypes.UpkeepResult{
 				{
-					Key: ktypes.UpkeepKey("1|1"),
+					Key: chain.UpkeepKey("1|1"),
 				},
 				{
-					Key: ktypes.UpkeepKey("1|2"),
+					Key: chain.UpkeepKey("1|2"),
 				},
 			},
 			AlreadyAccepted: []struct {
 				K ktypes.UpkeepKey
 				B bool
 			}{
-				{K: ktypes.UpkeepKey("1|1"), B: false},
-				{K: ktypes.UpkeepKey("1|2"), B: false},
+				{K: chain.UpkeepKey("1|1"), B: false},
+				{K: chain.UpkeepKey("1|2"), B: false},
 			},
 			ExpectedBool: true,
 		},
@@ -693,14 +693,14 @@ func TestShouldTransmitAcceptedReport(t *testing.T) {
 			Description: "Should not transmit if call to filter transmitted returns true",
 			ReportContents: []ktypes.UpkeepResult{
 				{
-					Key: ktypes.UpkeepKey("1|1"),
+					Key: chain.UpkeepKey("1|1"),
 				},
 			},
 			TransmitChecks: []struct {
 				K ktypes.UpkeepKey
 				B bool
 			}{
-				{K: ktypes.UpkeepKey("1|1"), B: true},
+				{K: chain.UpkeepKey("1|1"), B: true},
 			},
 			ExpectedBool: false,
 			Err:          nil,
@@ -710,14 +710,14 @@ func TestShouldTransmitAcceptedReport(t *testing.T) {
 			Description: "Should transmit if call to filter transmitted returns false",
 			ReportContents: []ktypes.UpkeepResult{
 				{
-					Key: ktypes.UpkeepKey("1|1"),
+					Key: chain.UpkeepKey("1|1"),
 				},
 			},
 			TransmitChecks: []struct {
 				K ktypes.UpkeepKey
 				B bool
 			}{
-				{K: ktypes.UpkeepKey("1|1"), B: false},
+				{K: chain.UpkeepKey("1|1"), B: false},
 			},
 			ExpectedBool: true,
 			Err:          nil,
@@ -727,18 +727,18 @@ func TestShouldTransmitAcceptedReport(t *testing.T) {
 			Description: "Should not transmit if one key in report has been transmitted",
 			ReportContents: []ktypes.UpkeepResult{
 				{
-					Key: ktypes.UpkeepKey("1|1"),
+					Key: chain.UpkeepKey("1|1"),
 				},
 				{
-					Key: ktypes.UpkeepKey("1|2"),
+					Key: chain.UpkeepKey("1|2"),
 				},
 			},
 			TransmitChecks: []struct {
 				K ktypes.UpkeepKey
 				B bool
 			}{
-				{K: ktypes.UpkeepKey("1|1"), B: false},
-				{K: ktypes.UpkeepKey("1|2"), B: true},
+				{K: chain.UpkeepKey("1|1"), B: false},
+				{K: chain.UpkeepKey("1|2"), B: true},
 			},
 			ExpectedBool: false,
 			Err:          nil,
@@ -781,7 +781,7 @@ func BenchmarkShouldTransmitAcceptedReport(b *testing.B) {
 	mf := &BenchmarkMockedFilterer{}
 
 	me.rtnKeys = []ktypes.UpkeepResult{
-		{Key: ktypes.UpkeepKey([]byte("1|1"))},
+		{Key: chain.UpkeepKey([]byte("1|1"))},
 	}
 
 	plugin := &keepers{

--- a/internal/keepers/ocr_test.go
+++ b/internal/keepers/ocr_test.go
@@ -3,13 +3,13 @@ package keepers
 import (
 	"context"
 	"fmt"
-	"github.com/smartcontractkit/ocr2keepers/pkg/chain"
 	"io"
 	"log"
 	"testing"
 	"time"
 
 	"github.com/smartcontractkit/libocr/offchainreporting2/types"
+	"github.com/smartcontractkit/ocr2keepers/pkg/chain"
 	ktypes "github.com/smartcontractkit/ocr2keepers/pkg/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"

--- a/internal/keepers/service.go
+++ b/internal/keepers/service.go
@@ -113,7 +113,7 @@ func (s *onDemandUpkeepService) CheckUpkeep(ctx context.Context, keys ...types.U
 			// the cache is a collection of keys (block & id) that map to cached
 			// results. if the same upkeep is checked at a block that has already been
 			// checked, return the cached result
-			if result, cached := s.cache.Get(string(key)); cached {
+			if result, cached := s.cache.Get(key.String()); cached {
 				results[i] = result
 			} else {
 				nonCachedKeysLock.Lock()
@@ -141,7 +141,7 @@ func (s *onDemandUpkeepService) CheckUpkeep(ctx context.Context, keys ...types.U
 
 	// Cache results
 	for i, u := range checkResults {
-		s.cache.Set(string(keys[nonCachedKeysIdxs[i]]), u, util.DefaultCacheExpiration)
+		s.cache.Set(keys[nonCachedKeysIdxs[i]].String(), u, util.DefaultCacheExpiration)
 		results[nonCachedKeysIdxs[i]] = u
 	}
 
@@ -241,7 +241,7 @@ func (s *onDemandUpkeepService) parallelCheck(ctx context.Context, keys []types.
 			defer wg.Done()
 
 			// no RPC lookups need to be done if a result has already been cached
-			result, cached := s.cache.Get(string(key))
+			result, cached := s.cache.Get(key.String())
 			if cached {
 				cacheHits++
 				if result.State == types.Eligible {
@@ -319,7 +319,7 @@ Outer:
 				// Cache results
 				for i := range result.Data {
 					res := result.Data[i]
-					s.cache.Set(string(res.Key), res, util.DefaultCacheExpiration)
+					s.cache.Set(res.Key.String(), res, util.DefaultCacheExpiration)
 					if res.State == types.Eligible {
 						sa.Append(res)
 					}

--- a/internal/keepers/service_test.go
+++ b/internal/keepers/service_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/smartcontractkit/ocr2keepers/pkg/chain"
 	"io"
 	"log"
 	"testing"
@@ -14,6 +13,7 @@ import (
 	"github.com/stretchr/testify/mock"
 
 	"github.com/smartcontractkit/ocr2keepers/internal/util"
+	"github.com/smartcontractkit/ocr2keepers/pkg/chain"
 	"github.com/smartcontractkit/ocr2keepers/pkg/types"
 	ktypes "github.com/smartcontractkit/ocr2keepers/pkg/types"
 )

--- a/internal/keepers/service_test.go
+++ b/internal/keepers/service_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"github.com/smartcontractkit/ocr2keepers/pkg/chain"
 	"io"
 	"log"
 	"testing"
@@ -19,7 +20,7 @@ import (
 
 func Test_onDemandUpkeepService_CheckUpkeep(t *testing.T) {
 	testId := ktypes.UpkeepIdentifier("1")
-	testKey := ktypes.UpkeepKey(fmt.Sprintf("1|%s", string(testId)))
+	testKey := chain.UpkeepKey(fmt.Sprintf("1|%s", string(testId)))
 
 	tests := []struct {
 		Name           string
@@ -111,7 +112,7 @@ func Test_onDemandUpkeepService_SampleUpkeeps(t *testing.T) {
 	returnResults := make(ktypes.UpkeepResults, 5)
 	for i := 0; i < 5; i++ {
 		returnResults[i] = ktypes.UpkeepResult{
-			Key:         ktypes.UpkeepKey(fmt.Sprintf("1|%d", i+1)),
+			Key:         chain.UpkeepKey(fmt.Sprintf("1|%d", i+1)),
 			State:       types.NotEligible,
 			PerformData: []byte{},
 		}
@@ -147,7 +148,7 @@ func Test_onDemandUpkeepService_runSamplingUpkeeps(t *testing.T) {
 		for _, key := range keys[:5] {
 			var found bool
 			for _, actualKey := range actualKeys {
-				if bytes.Equal(actualKey, key) {
+				if bytes.Equal([]byte(actualKey.String()), []byte(key.String())) {
 					found = true
 					break
 				}
@@ -168,7 +169,7 @@ func Test_onDemandUpkeepService_runSamplingUpkeeps(t *testing.T) {
 
 		actives := make([]ktypes.UpkeepKey, 10)
 		for i := 0; i < 10; i++ {
-			actives[i] = ktypes.UpkeepKey(fmt.Sprintf("1|%d", i+1))
+			actives[i] = chain.UpkeepKey(fmt.Sprintf("1|%d", i+1))
 		}
 
 		rg.Mock.On("GetActiveUpkeepKeys", mock.Anything, types.BlockKey("0")).
@@ -301,7 +302,7 @@ func Test_onDemandUpkeepService_runSamplingUpkeeps(t *testing.T) {
 
 		actives := make([]ktypes.UpkeepKey, 10)
 		for i := 0; i < 10; i++ {
-			actives[i] = ktypes.UpkeepKey(fmt.Sprintf("1|%d", i+1))
+			actives[i] = chain.UpkeepKey(fmt.Sprintf("1|%d", i+1))
 		}
 
 		rg.Mock.On("GetActiveUpkeepKeys", mock.Anything, ktypes.BlockKey("0")).

--- a/internal/keepers/util.go
+++ b/internal/keepers/util.go
@@ -10,10 +10,9 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/smartcontractkit/ocr2keepers/pkg/chain"
-
 	"github.com/smartcontractkit/libocr/offchainreporting2/types"
 	"github.com/smartcontractkit/ocr2keepers/internal/util"
+	"github.com/smartcontractkit/ocr2keepers/pkg/chain"
 	ktypes "github.com/smartcontractkit/ocr2keepers/pkg/types"
 )
 

--- a/internal/keepers/util.go
+++ b/internal/keepers/util.go
@@ -135,6 +135,7 @@ func shuffledDedupedKeyList(attributed []types.AttributedObservation, key [16]by
 		// a single observation returning an error here can void all other
 		// good observations. ensure this loop continues on error, but collect
 		// them and throw an error if ALL observations fail at this point.
+		// TODO we can't rely on this concrete type for decoding/encoding
 		var keys []chain.UpkeepKey
 		err = decode(b, &keys)
 		if err != nil {

--- a/internal/keepers/util_test.go
+++ b/internal/keepers/util_test.go
@@ -2,10 +2,12 @@ package keepers
 
 import (
 	"fmt"
-	"github.com/smartcontractkit/ocr2keepers/pkg/chain"
 	"math/rand"
 	"sort"
+	"strings"
 	"testing"
+
+	"github.com/smartcontractkit/ocr2keepers/pkg/chain"
 
 	"github.com/smartcontractkit/libocr/offchainreporting2/types"
 	ktypes "github.com/smartcontractkit/ocr2keepers/pkg/types"
@@ -253,7 +255,8 @@ func FuzzLimitedLengthEncode(f *testing.F) {
 
 		keys := make([]ktypes.UpkeepKey, a)
 		for i := 0; i < a; i++ {
-			k := make([]byte, rand.Intn(b))
+			k := strings.Repeat("1", rand.Intn(b)+3)
+			k = k[:1] + "|" + k[2:]
 			keys[i] = chain.UpkeepKey(k)
 		}
 
@@ -266,10 +269,11 @@ func FuzzLimitedLengthEncode(f *testing.F) {
 			output := make([]ktypes.UpkeepKey, 0)
 			outputKeys := make([]chain.UpkeepKey, 0)
 			err = decode(bt, &outputKeys)
+			assert.NoError(t, err)
+
 			for _, o := range outputKeys {
 				output = append(output, o)
 			}
-			assert.NoError(t, err)
 
 			assert.Greater(t, len(bt), 0, "length of bytes :: keys: %d; length: %d", a, b)
 			assert.Greater(t, len(output), 0, "min number of keys :: keys: %d; length: %d", a, b)

--- a/internal/keepers/util_test.go
+++ b/internal/keepers/util_test.go
@@ -7,9 +7,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/smartcontractkit/ocr2keepers/pkg/chain"
-
 	"github.com/smartcontractkit/libocr/offchainreporting2/types"
+	"github.com/smartcontractkit/ocr2keepers/pkg/chain"
 	ktypes "github.com/smartcontractkit/ocr2keepers/pkg/types"
 	"github.com/stretchr/testify/assert"
 )

--- a/pkg/chain/evmregistry_test.go
+++ b/pkg/chain/evmregistry_test.go
@@ -56,7 +56,7 @@ func TestCheckUpkeep(t *testing.T) {
 	err := pdataABI.UnpackIntoInterface(ret0, "check", wrappedPerformData)
 	require.NoError(t, err)
 
-	upkeepKey := types.UpkeepKey("1|1234")
+	upkeepKey := UpkeepKey("1|1234")
 	_, expectedUpkeep, err := BlockAndIdFromKey(upkeepKey)
 	require.NoError(t, err)
 

--- a/pkg/chain/evmreports.go
+++ b/pkg/chain/evmreports.go
@@ -2,8 +2,9 @@ package chain
 
 import (
 	"fmt"
-	"github.com/ethereum/go-ethereum/accounts/abi"
 	"math/big"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
 
 	ktypes "github.com/smartcontractkit/ocr2keepers/pkg/types"
 )

--- a/pkg/chain/evmreports.go
+++ b/pkg/chain/evmreports.go
@@ -2,10 +2,8 @@ package chain
 
 import (
 	"fmt"
-	"math/big"
-	"strings"
-
 	"github.com/ethereum/go-ethereum/accounts/abi"
+	"math/big"
 
 	ktypes "github.com/smartcontractkit/ocr2keepers/pkg/types"
 )
@@ -168,20 +166,20 @@ type wrappedPerform struct {
 }
 
 func BlockAndIdFromKey(key ktypes.UpkeepKey) (ktypes.BlockKey, *big.Int, error) {
-	parts := strings.Split(string(key), separator)
-	if len(parts) != 2 {
-		return "", nil, fmt.Errorf("%w: missing data in upkeep key", ErrUpkeepKeyNotParsable)
+	blockKey, upkeepID, err := key.BlockKeyAndUpkeepID()
+	if err != nil {
+		return "", nil, err
 	}
 
 	id := new(big.Int)
-	_, ok := id.SetString(parts[1], 10)
+	_, ok := id.SetString(string(upkeepID), 10)
 	if !ok {
 		return "", nil, fmt.Errorf("%w: must be big int", ErrUpkeepKeyNotParsable)
 	}
 
-	return ktypes.BlockKey(parts[0]), id, nil
+	return blockKey, id, nil
 }
 
 func BlockAndIdToKey(block *big.Int, id *big.Int) ktypes.UpkeepKey {
-	return ktypes.UpkeepKey(fmt.Sprintf("%s%s%s", block, separator, id))
+	return UpkeepKey(fmt.Sprintf("%s%s%s", block, separator, id))
 }

--- a/pkg/chain/evmreports_test.go
+++ b/pkg/chain/evmreports_test.go
@@ -20,7 +20,7 @@ func TestEncodeReport_MultiplePerforms(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		input := []ktypes.UpkeepResult{
 			{
-				Key:              ktypes.UpkeepKey("42|18"),
+				Key:              UpkeepKey("42|18"),
 				PerformData:      []byte("hello"),
 				FastGasWei:       big.NewInt(16),
 				LinkNative:       big.NewInt(8),
@@ -28,7 +28,7 @@ func TestEncodeReport_MultiplePerforms(t *testing.T) {
 				CheckBlockHash:   [32]byte{1},
 			},
 			{
-				Key:              ktypes.UpkeepKey("43|23"),
+				Key:              UpkeepKey("43|23"),
 				PerformData:      []byte("long perform data that takes up more than 32 bytes to show how byte arrays are abi encoded. this should take up multiple slots."),
 				FastGasWei:       big.NewInt(8),
 				LinkNative:       big.NewInt(16),
@@ -75,7 +75,7 @@ func TestEncodeReport_MultiplePerforms(t *testing.T) {
 
 	t.Run("Key Parse Error", func(t *testing.T) {
 		input := []ktypes.UpkeepResult{
-			{Key: ktypes.UpkeepKey([]byte("1")), PerformData: []byte("hello")},
+			{Key: UpkeepKey([]byte("1")), PerformData: []byte("hello")},
 		}
 
 		encoder := &evmReportEncoder{}
@@ -89,7 +89,7 @@ func TestEncodeReport_MultiplePerforms(t *testing.T) {
 func TestEncodeReport_EmptyPerformData(t *testing.T) {
 	input := []ktypes.UpkeepResult{
 		{
-			Key:              ktypes.UpkeepKey([]byte("43|18")),
+			Key:              UpkeepKey([]byte("43|18")),
 			PerformData:      []byte{},
 			FastGasWei:       big.NewInt(8),
 			LinkNative:       big.NewInt(16),
@@ -125,7 +125,7 @@ func TestEncodeReport_EmptyPerformData(t *testing.T) {
 func TestDecodeReport(t *testing.T) {
 	expected := []ktypes.UpkeepResult{
 		{
-			Key:              ktypes.UpkeepKey([]byte("43|18")),
+			Key:              UpkeepKey([]byte("43|18")),
 			State:            ktypes.Eligible, // it is assumed that all items in a report were eligible
 			PerformData:      []byte{},
 			FastGasWei:       big.NewInt(8),
@@ -159,9 +159,9 @@ func TestDecodeReport(t *testing.T) {
 }
 
 func BenchmarkEncodeReport(b *testing.B) {
-	key1 := ktypes.UpkeepKey([]byte("1239428374|187689279234987"))
-	key2 := ktypes.UpkeepKey([]byte("1239428374|187689279234989"))
-	key3 := ktypes.UpkeepKey([]byte("1239428375|187689279234987"))
+	key1 := UpkeepKey([]byte("1239428374|187689279234987"))
+	key2 := UpkeepKey([]byte("1239428374|187689279234989"))
+	key3 := UpkeepKey([]byte("1239428375|187689279234987"))
 
 	noData := []byte{}
 	smallData := make([]byte, 12)

--- a/pkg/chain/upkeep_key.go
+++ b/pkg/chain/upkeep_key.go
@@ -1,0 +1,22 @@
+package chain
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/smartcontractkit/ocr2keepers/pkg/types"
+)
+
+type UpkeepKey []byte
+
+func (u UpkeepKey) BlockKeyAndUpkeepID() (types.BlockKey, types.UpkeepIdentifier, error) {
+	components := strings.Split(string(u), "|")
+	if len(components) == 2 {
+		return types.BlockKey(components[0]), types.UpkeepIdentifier(components[1]), nil
+	}
+	return types.BlockKey(""), types.UpkeepIdentifier(""), fmt.Errorf("%w: missing data in upkeep key", ErrUpkeepKeyNotParsable)
+}
+
+func (u UpkeepKey) String() string {
+	return string(u)
+}

--- a/pkg/chain/upkeep_key.go
+++ b/pkg/chain/upkeep_key.go
@@ -1,6 +1,7 @@
 package chain
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -10,7 +11,7 @@ import (
 type UpkeepKey []byte
 
 func (u UpkeepKey) BlockKeyAndUpkeepID() (types.BlockKey, types.UpkeepIdentifier, error) {
-	components := strings.Split(string(u), "|")
+	components := strings.Split(u.String(), "|")
 	if len(components) == 2 {
 		return types.BlockKey(components[0]), types.UpkeepIdentifier(components[1]), nil
 	}
@@ -19,4 +20,35 @@ func (u UpkeepKey) BlockKeyAndUpkeepID() (types.BlockKey, types.UpkeepIdentifier
 
 func (u UpkeepKey) String() string {
 	return string(u)
+}
+
+func (u *UpkeepKey) UnmarshalJSON(b []byte) error {
+	var key []uint8
+	if err := json.Unmarshal(b, &key); err != nil {
+		return err
+	}
+
+	if !u.isValid(string(key)) {
+		return ErrUpkeepKeyNotParsable
+	}
+
+	*u = UpkeepKey(key)
+	return nil
+}
+
+func (u *UpkeepKey) isValid(v string) bool {
+	if strings.Count(v, separator) != 1 {
+		return false
+	}
+
+	components := strings.Split(v, separator)
+	if len(components) != 2 {
+		return false
+	}
+
+	if components[0] == "" || components[1] == "" {
+		return false
+	}
+
+	return true
 }

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -70,7 +70,10 @@ type Address []byte
 
 // UpkeepKey is an identifier of an upkeep at a moment in time, typically an
 // upkeep at a block number
-type UpkeepKey []byte
+type UpkeepKey interface {
+	BlockKeyAndUpkeepID() (BlockKey, UpkeepIdentifier, error)
+	fmt.Stringer
+}
 
 // UpkeepIdentifier is an identifier for an active upkeep, typically a big int
 type UpkeepIdentifier []byte


### PR DESCRIPTION
~~In this PR, I've added a BlockKeyAndUpkeepID function to the UpkeepKey type. This function performs a string split on `|` and returns a block key and an upkeep ID as a pair of values.~~

~~I was going to add two separate functions, one for each value, but given that both values are often used together, I thought returning the values as a pair made sense.~~

~~If we ever change the UpkeepKey type to encompass more than two values, it would probably make sense to have separate functions for each value, depending on how the client code uses them.~~

In this PR, I've updated the UpkeepKey type to be an interface with a BlockKeyAndUpkeepID function. The UpkeepKey interface is also now a Stringer, and also supports JSON unmarshalling.

I've added an implementation of this interface to the `chain` package. The BlockKeyAndUpkeepID function returns a BlockKey and an UpkeepIdentifier, though these are often cast to strings in the client code.

A significant number of tests have been updated to use the new chain.UpkeepKey implementation in place of the types.UpkeepKey interface, as these tests instantiate UpkeepKeys as part of their test cases.
