### PR TITLE
Assign median block to keys

### DIFF
--- a/internal/keepers/util_test.go
+++ b/internal/keepers/util_test.go
@@ -194,6 +194,45 @@ func TestShuffledDedupedKeyList(t *testing.T) {
 				chain.UpkeepKey("2|5"),
 			},
 		},
+		{
+			observations: [][]ktypes.UpkeepKey{
+				{
+					chain.UpkeepKey("2|1"),
+				},
+				{
+					chain.UpkeepKey("20|5"),
+				},
+				{
+					chain.UpkeepKey("200|3"),
+				},
+			},
+			expected: []ktypes.UpkeepKey{
+				chain.UpkeepKey("20|3"),
+				chain.UpkeepKey("20|1"),
+				chain.UpkeepKey("20|5"),
+			},
+		},
+		{
+			observations: [][]ktypes.UpkeepKey{
+				{
+					chain.UpkeepKey("2|1"),
+				},
+				{
+					chain.UpkeepKey("3|5"),
+				},
+				{
+					chain.UpkeepKey("20|5"),
+				},
+				{
+					chain.UpkeepKey("200|3"),
+				},
+			},
+			expected: []ktypes.UpkeepKey{
+				chain.UpkeepKey("3|3"),
+				chain.UpkeepKey("3|1"),
+				chain.UpkeepKey("3|5"),
+			},
+		},
 	} {
 		var attr []types.AttributedObservation
 		for _, o := range tc.observations {

--- a/internal/keepers/util_test.go
+++ b/internal/keepers/util_test.go
@@ -101,8 +101,8 @@ func TestShuffledDedupedKeyList(t *testing.T) {
 				},
 			},
 			expected: []ktypes.UpkeepKey{
-				chain.UpkeepKey("2|3"),
-				chain.UpkeepKey("3|1"),
+				chain.UpkeepKey("1|3"),
+				chain.UpkeepKey("1|1"),
 				chain.UpkeepKey("1|2"),
 			},
 		},
@@ -171,7 +171,7 @@ func TestShuffledDedupedKeyList(t *testing.T) {
 				},
 			},
 			expected: []ktypes.UpkeepKey{
-				chain.UpkeepKey("3|2"),
+				chain.UpkeepKey("2|2"),
 				chain.UpkeepKey("2|1"),
 				chain.UpkeepKey("2|3"),
 			},


### PR DESCRIPTION
In this PR, I'm modifying the dedupe functionality, so that the upkeep keys are modified to use the median block key from all upkeep keys

Given the the following set of upkeep keys:

``` 
[{block1|key1}, {block2|key1}, {block3|key2}, {block2|key3}]
```

The block keys are as follows:

```block1, block2, block2, block3```

The median of which is `block2`. 

The upkeep keys would then be updated to use `block2` as the block key, resulting in the following upkeep keys:

``` 
[{block2|key1}, {block2|key1}, {block2|key2}, {block2|key3}]
```

With the dedupe operation applied, this list is reduced down to the following:

```
[{block2|key1}, {block2|key2}, {block2|key3}]
```
