### PR TITLE
clean up config defaults

### DIFF
--- a/internal/keepers/factory.go
+++ b/internal/keepers/factory.go
@@ -77,7 +77,7 @@ func (d *keepersReportingFactory) NewReportingPlugin(c types.ReportingPluginConf
 			// with performData of arbitrary length
 			MaxReportLength: 10_000, // TODO (config): pick sane limit based on expected performData size. maybe set this to block size limit or 2/3 block size limit?
 		},
-		UniqueReports: offChainCfg.UniqueReports,
+		UniqueReports: false,
 	}
 
 	// TODO (config): sample ratio is calculated with number of rounds, number

--- a/internal/keepers/factory.go
+++ b/internal/keepers/factory.go
@@ -87,18 +87,9 @@ func (d *keepersReportingFactory) NewReportingPlugin(c types.ReportingPluginConf
 	// performance of the nodes in real time. that is, start at 1 and increment
 	// after some blocks pass until a stable number is reached.
 	var p float64
-	if len(offChainCfg.TargetProbability) == 0 {
-		// TODO: Combine all default values in DecodeOffchainConfig
-		offChainCfg.TargetProbability = "0.99999"
-	}
-
 	p, err = strconv.ParseFloat(offChainCfg.TargetProbability, 32)
 	if err != nil {
 		return nil, info, fmt.Errorf("%w: failed to parse configured probability", err)
-	}
-
-	if offChainCfg.TargetInRounds <= 0 {
-		offChainCfg.TargetInRounds = 1
 	}
 
 	sample, err := sampleFromProbability(offChainCfg.TargetInRounds, c.N-c.F, float32(p))

--- a/internal/keepers/factory.go
+++ b/internal/keepers/factory.go
@@ -77,6 +77,8 @@ func (d *keepersReportingFactory) NewReportingPlugin(c types.ReportingPluginConf
 			// with performData of arbitrary length
 			MaxReportLength: 10_000, // TODO (config): pick sane limit based on expected performData size. maybe set this to block size limit or 2/3 block size limit?
 		},
+		// UniqueReports increases the threshold of signatures needed for quorum to (n+f)/2 so that it's guaranteed a unique report is generated per round.
+		// Fixed to false for ocr2keepers, as we always expect f+1 signatures on a report on contract and do not support uniqueReports quorum
 		UniqueReports: false,
 	}
 

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -144,23 +144,37 @@ func DecodeOffchainConfig(b []byte) (OffchainConfig, error) {
 		err = json.Unmarshal(b, &config)
 	}
 
-	if config.PerformLockoutWindow == 0 {
-		config.PerformLockoutWindow = 100 * 12 * 1000 // default of 100 blocks * 12 second blocks
+	if config.PerformLockoutWindow <= 0 {
+		config.PerformLockoutWindow = 20 * 60 * 1000 // default of 20 minutes (100 blocks on eth)
 	}
 
-	if config.SamplingJobDuration == 0 {
+	config.UniqueReports = false // hardcoded to false, TODO(AUTO-2029): remove this config alltogether
+
+	if len(config.TargetProbability) == 0 {
+		config.TargetProbability = "0.99999"
+	}
+
+	if config.TargetInRounds <= 0 {
+		config.TargetInRounds = 1
+	}
+
+	if config.SamplingJobDuration <= 0 {
 		config.SamplingJobDuration = 3000 // default of 3 seconds if not set
 	}
 
-	if config.GasLimitPerReport == 0 {
+	if config.MinConfirmations <= 0 {
+		config.MinConfirmations = 0 // default of 0
+	}
+
+	if config.GasLimitPerReport <= 0 {
 		config.GasLimitPerReport = 5_300_000
 	}
 
-	if config.GasOverheadPerUpkeep == 0 {
+	if config.GasOverheadPerUpkeep <= 0 {
 		config.GasOverheadPerUpkeep = 300_000
 	}
 
-	if config.MaxUpkeepBatchSize == 0 {
+	if config.MaxUpkeepBatchSize <= 0 {
 		config.MaxUpkeepBatchSize = 1
 	}
 

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -106,9 +106,6 @@ type OffchainConfig struct {
 	// 100 blocks * average block time. Units are in milliseconds
 	PerformLockoutWindow int64 `json:"performLockoutWindow"`
 
-	// UniqueReports sets quorum requirements for the OCR process
-	UniqueReports bool `json:"uniqueReports"`
-
 	// TargetProbability is the probability that all upkeeps will be checked
 	// within the provided number rounds
 	TargetProbability string `json:"targetProbability"`
@@ -148,8 +145,6 @@ func DecodeOffchainConfig(b []byte) (OffchainConfig, error) {
 		config.PerformLockoutWindow = 20 * 60 * 1000 // default of 20 minutes (100 blocks on eth)
 	}
 
-	config.UniqueReports = false // hardcoded to false, TODO(AUTO-2029): remove this config alltogether
-
 	if len(config.TargetProbability) == 0 {
 		config.TargetProbability = "0.99999"
 	}
@@ -166,11 +161,11 @@ func DecodeOffchainConfig(b []byte) (OffchainConfig, error) {
 		config.MinConfirmations = 0 // default of 0
 	}
 
-	if config.GasLimitPerReport <= 0 {
+	if config.GasLimitPerReport == 0 { // defined as uint so cannot be < 0
 		config.GasLimitPerReport = 5_300_000
 	}
 
-	if config.GasOverheadPerUpkeep <= 0 {
+	if config.GasOverheadPerUpkeep == 0 { // defined as uint so cannot be < 0
 		config.GasOverheadPerUpkeep = 300_000
 	}
 

--- a/pkg/types/types_test.go
+++ b/pkg/types/types_test.go
@@ -1,0 +1,122 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDecode(t *testing.T) {
+	tests := []struct {
+		Name              string
+		EncodedData       []byte
+		ExpectedErrString string
+		ExpectedConfig    OffchainConfig
+	}{
+		{Name: "Happy path", EncodedData: []byte(`
+		{
+			"performLockoutWindow": 1000,
+			"targetProbability": "0.999",
+			"targetInRounds": 1,
+			"samplingJobDuration": 1000,
+			"minConfirmations": 10,
+			"gasLimitPerReport": 10,
+			"gasOverheadPerUpkeep": 100,
+			"maxUpkeepBatchSize": 100
+		}
+	`), ExpectedErrString: "", ExpectedConfig: OffchainConfig{
+			PerformLockoutWindow: 1000,
+			TargetProbability:    "0.999",
+			TargetInRounds:       1,
+			SamplingJobDuration:  1000,
+			MinConfirmations:     10,
+			GasLimitPerReport:    10,
+			GasOverheadPerUpkeep: 100,
+			MaxUpkeepBatchSize:   100,
+		}},
+
+		{Name: "Extra field uniqueReports", EncodedData: []byte(`
+		{
+			"performLockoutWindow": 1000,
+			"uniqueReports": true,
+			"targetProbability": "0.999",
+			"targetInRounds": 1,
+			"samplingJobDuration": 1000,
+			"minConfirmations": 10,
+			"gasLimitPerReport": 10,
+			"gasOverheadPerUpkeep": 100,
+			"maxUpkeepBatchSize": 100
+		}
+	`), ExpectedErrString: "", ExpectedConfig: OffchainConfig{
+			PerformLockoutWindow: 1000,
+			TargetProbability:    "0.999",
+			TargetInRounds:       1,
+			SamplingJobDuration:  1000,
+			MinConfirmations:     10,
+			GasLimitPerReport:    10,
+			GasOverheadPerUpkeep: 100,
+			MaxUpkeepBatchSize:   100,
+		}},
+
+		{Name: "Missing values", EncodedData: []byte(`
+		{
+		}
+	`), ExpectedErrString: "", ExpectedConfig: OffchainConfig{
+			PerformLockoutWindow: 1200000,
+			TargetProbability:    "0.99999",
+			TargetInRounds:       1,
+			SamplingJobDuration:  3000,
+			MinConfirmations:     0,
+			GasLimitPerReport:    5_300_000,
+			GasOverheadPerUpkeep: 300_000,
+			MaxUpkeepBatchSize:   1,
+		}},
+
+		{Name: "Negative values", EncodedData: []byte(`
+		{
+			"performLockoutWindow": -1000,
+			"targetProbability": "0.999",
+			"targetInRounds": -1,
+			"samplingJobDuration": -1000,
+			"minConfirmations": -10,
+			"gasLimitPerReport": 0,
+			"gasOverheadPerUpkeep": 0,
+			"maxUpkeepBatchSize": -100
+		}
+	`), ExpectedErrString: "", ExpectedConfig: OffchainConfig{
+			PerformLockoutWindow: 1200000,
+			TargetProbability:    "0.999",
+			TargetInRounds:       1,
+			SamplingJobDuration:  3000,
+			MinConfirmations:     0,
+			GasLimitPerReport:    5_300_000,
+			GasOverheadPerUpkeep: 300_000,
+			MaxUpkeepBatchSize:   1,
+		}},
+
+		{Name: "Unexpected type", EncodedData: []byte(`
+		{
+			"performLockoutWindow": "string",
+			"targetProbability": "0.999",
+			"targetInRounds": -1,
+			"samplingJobDuration": -1000,
+			"minConfirmations": -10,
+			"gasLimitPerReport": 0,
+			"gasOverheadPerUpkeep": 0,
+			"maxUpkeepBatchSize": -100
+		}
+	`), ExpectedErrString: "json: cannot unmarshal string", ExpectedConfig: OffchainConfig{}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			config, err := DecodeOffchainConfig(test.EncodedData)
+			if test.ExpectedErrString != "" {
+				assert.ErrorContains(t, err, test.ExpectedErrString)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, config, test.ExpectedConfig)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- Clean up defaults for all values
- Remove uniqueReports config which was an unnecessary risk
- Add tests for decoding config

Corresponding CL PR: https://github.com/smartcontractkit/chainlink/pull/8440/files