### PR TITLE
Add an UpkeepObservation type 

### DIFF
--- a/internal/keepers/ocr.go
+++ b/internal/keepers/ocr.go
@@ -57,7 +57,9 @@ func (k *keepers) Observation(ctx context.Context, rt types.ReportTimestamp, _ t
 	// should be more uniform for all nodes
 	keys := keyList(filterUpkeeps(results, ktypes.Eligible))
 
-	obs := &ktypes.UpkeepObservation{}
+	obs := &ktypes.UpkeepObservation{
+		UpkeepIdentifiers: []ktypes.UpkeepIdentifier{},
+	}
 	// TODO get latest block from head ticker
 
 	if len(keys) > 0 {

--- a/internal/keepers/ocr.go
+++ b/internal/keepers/ocr.go
@@ -57,7 +57,20 @@ func (k *keepers) Observation(ctx context.Context, rt types.ReportTimestamp, _ t
 	// should be more uniform for all nodes
 	keys := keyList(filterUpkeeps(results, ktypes.Eligible))
 
-	b, err := limitedLengthEncode(keys, maxObservationLength)
+	obs := &ktypes.UpkeepObservation{}
+	// TODO get latest block from head ticker
+
+	if len(keys) > 0 {
+		var identifiers []ktypes.UpkeepIdentifier
+		for _, upkeepKey := range keys {
+			blockKey, upkeepID, _ := upkeepKey.BlockKeyAndUpkeepID()
+			identifiers = append(identifiers, upkeepID)
+			obs.BlockKey = blockKey
+		}
+		obs.UpkeepIdentifiers = identifiers
+	}
+
+	b, err := limitedLengthEncode(obs, maxObservationLength)
 	if err != nil {
 		return nil, fmt.Errorf("%w: failed to encode upkeep keys for observation: %s", err, lCtx)
 	}

--- a/internal/keepers/ocr_test.go
+++ b/internal/keepers/ocr_test.go
@@ -233,9 +233,30 @@ func TestReport(t *testing.T) {
 			ReportGasLimit: 10000000,
 			Ctx:            func() (context.Context, func()) { return context.Background(), func() {} },
 			Observations: []types.AttributedObservation{
-				{Observation: types.Observation(mustEncodeKeys([]ktypes.UpkeepKey{chain.UpkeepKey("1|1")}))},
-				{Observation: types.Observation(mustEncodeKeys([]ktypes.UpkeepKey{chain.UpkeepKey("1|1")}))},
-				{Observation: types.Observation(mustEncodeKeys([]ktypes.UpkeepKey{chain.UpkeepKey("1|1")}))},
+				{Observation: types.Observation(mustEncodeUpkeepObservation(
+					&ktypes.UpkeepObservation{
+						BlockKey: ktypes.BlockKey("1"),
+						UpkeepIdentifiers: []ktypes.UpkeepIdentifier{
+							ktypes.UpkeepIdentifier("1"),
+						},
+					})),
+				},
+				{Observation: types.Observation(mustEncodeUpkeepObservation(
+					&ktypes.UpkeepObservation{
+						BlockKey: ktypes.BlockKey("1"),
+						UpkeepIdentifiers: []ktypes.UpkeepIdentifier{
+							ktypes.UpkeepIdentifier("1"),
+						},
+					})),
+				},
+				{Observation: types.Observation(mustEncodeUpkeepObservation(
+					&ktypes.UpkeepObservation{
+						BlockKey: ktypes.BlockKey("1"),
+						UpkeepIdentifiers: []ktypes.UpkeepIdentifier{
+							ktypes.UpkeepIdentifier("1"),
+						},
+					})),
+				},
 			},
 			Checks: checks{
 				K: []ktypes.UpkeepKey{
@@ -254,9 +275,30 @@ func TestReport(t *testing.T) {
 			ReportGasLimit: 10000000,
 			Ctx:            func() (context.Context, func()) { return context.WithTimeout(context.Background(), time.Second) },
 			Observations: []types.AttributedObservation{
-				{Observation: types.Observation(mustEncodeKeys([]ktypes.UpkeepKey{chain.UpkeepKey("1|1")}))},
-				{Observation: types.Observation(mustEncodeKeys([]ktypes.UpkeepKey{chain.UpkeepKey("1|1")}))},
-				{Observation: types.Observation(mustEncodeKeys([]ktypes.UpkeepKey{chain.UpkeepKey("1|1")}))},
+				{Observation: types.Observation(mustEncodeUpkeepObservation(
+					&ktypes.UpkeepObservation{
+						BlockKey: ktypes.BlockKey("1"),
+						UpkeepIdentifiers: []ktypes.UpkeepIdentifier{
+							ktypes.UpkeepIdentifier("1"),
+						},
+					})),
+				},
+				{Observation: types.Observation(mustEncodeUpkeepObservation(
+					&ktypes.UpkeepObservation{
+						BlockKey: ktypes.BlockKey("1"),
+						UpkeepIdentifiers: []ktypes.UpkeepIdentifier{
+							ktypes.UpkeepIdentifier("1"),
+						},
+					})),
+				},
+				{Observation: types.Observation(mustEncodeUpkeepObservation(
+					&ktypes.UpkeepObservation{
+						BlockKey: ktypes.BlockKey("1"),
+						UpkeepIdentifiers: []ktypes.UpkeepIdentifier{
+							ktypes.UpkeepIdentifier("1"),
+						},
+					})),
+				},
 			},
 			Checks: checks{
 				K: []ktypes.UpkeepKey{
@@ -275,9 +317,30 @@ func TestReport(t *testing.T) {
 			ReportGasLimit: 10000000,
 			Ctx:            func() (context.Context, func()) { return context.WithTimeout(context.Background(), time.Second) },
 			Observations: []types.AttributedObservation{
-				{Observation: types.Observation(mustEncodeKeys([]ktypes.UpkeepKey{chain.UpkeepKey("1|1")}))},
-				{Observation: types.Observation(mustEncodeKeys([]ktypes.UpkeepKey{chain.UpkeepKey("1|1")}))},
-				{Observation: types.Observation(mustEncodeKeys([]ktypes.UpkeepKey{chain.UpkeepKey("1|1")}))},
+				{Observation: types.Observation(mustEncodeUpkeepObservation(
+					&ktypes.UpkeepObservation{
+						BlockKey: ktypes.BlockKey("1"),
+						UpkeepIdentifiers: []ktypes.UpkeepIdentifier{
+							ktypes.UpkeepIdentifier("1"),
+						},
+					})),
+				},
+				{Observation: types.Observation(mustEncodeUpkeepObservation(
+					&ktypes.UpkeepObservation{
+						BlockKey: ktypes.BlockKey("1"),
+						UpkeepIdentifiers: []ktypes.UpkeepIdentifier{
+							ktypes.UpkeepIdentifier("1"),
+						},
+					})),
+				},
+				{Observation: types.Observation(mustEncodeUpkeepObservation(
+					&ktypes.UpkeepObservation{
+						BlockKey: ktypes.BlockKey("1"),
+						UpkeepIdentifiers: []ktypes.UpkeepIdentifier{
+							ktypes.UpkeepIdentifier("1"),
+						},
+					})),
+				},
 			},
 			Checks: checks{
 				K: []ktypes.UpkeepKey{chain.UpkeepKey("1|1")},
@@ -293,9 +356,31 @@ func TestReport(t *testing.T) {
 			ReportGasLimit: 10000000,
 			Ctx:            func() (context.Context, func()) { return context.Background(), func() {} },
 			Observations: []types.AttributedObservation{
-				{Observation: types.Observation(mustEncodeKeys([]ktypes.UpkeepKey{chain.UpkeepKey("1|1")}))},
-				{Observation: types.Observation(mustEncodeKeys([]ktypes.UpkeepKey{chain.UpkeepKey("1|2"), chain.UpkeepKey("1|1")}))},
-				{Observation: types.Observation(mustEncodeKeys([]ktypes.UpkeepKey{chain.UpkeepKey("1|1")}))},
+				{Observation: types.Observation(mustEncodeUpkeepObservation(
+					&ktypes.UpkeepObservation{
+						BlockKey: ktypes.BlockKey("1"),
+						UpkeepIdentifiers: []ktypes.UpkeepIdentifier{
+							ktypes.UpkeepIdentifier("1"),
+						},
+					})),
+				},
+				{Observation: types.Observation(mustEncodeUpkeepObservation(
+					&ktypes.UpkeepObservation{
+						BlockKey: ktypes.BlockKey("1"),
+						UpkeepIdentifiers: []ktypes.UpkeepIdentifier{
+							ktypes.UpkeepIdentifier("2"),
+							ktypes.UpkeepIdentifier("1"),
+						},
+					})),
+				},
+				{Observation: types.Observation(mustEncodeUpkeepObservation(
+					&ktypes.UpkeepObservation{
+						BlockKey: ktypes.BlockKey("1"),
+						UpkeepIdentifiers: []ktypes.UpkeepIdentifier{
+							ktypes.UpkeepIdentifier("1"),
+						},
+					})),
+				},
 			},
 			Checks: checks{
 				K: []ktypes.UpkeepKey{
@@ -325,9 +410,31 @@ func TestReport(t *testing.T) {
 			ReportGasLimit: 10000000,
 			Ctx:            func() (context.Context, func()) { return context.Background(), func() {} },
 			Observations: []types.AttributedObservation{
-				{Observation: types.Observation(mustEncodeKeys([]ktypes.UpkeepKey{chain.UpkeepKey([]byte("1|2"))}))},
-				{Observation: types.Observation(mustEncodeKeys([]ktypes.UpkeepKey{chain.UpkeepKey([]byte("1|1")), chain.UpkeepKey([]byte("1|2"))}))},
-				{Observation: types.Observation(mustEncodeKeys([]ktypes.UpkeepKey{chain.UpkeepKey([]byte("1|2"))}))},
+				{Observation: types.Observation(mustEncodeUpkeepObservation(
+					&ktypes.UpkeepObservation{
+						BlockKey: ktypes.BlockKey("1"),
+						UpkeepIdentifiers: []ktypes.UpkeepIdentifier{
+							ktypes.UpkeepIdentifier("2"),
+						},
+					})),
+				},
+				{Observation: types.Observation(mustEncodeUpkeepObservation(
+					&ktypes.UpkeepObservation{
+						BlockKey: ktypes.BlockKey("1"),
+						UpkeepIdentifiers: []ktypes.UpkeepIdentifier{
+							ktypes.UpkeepIdentifier("1"),
+							ktypes.UpkeepIdentifier("2"),
+						},
+					})),
+				},
+				{Observation: types.Observation(mustEncodeUpkeepObservation(
+					&ktypes.UpkeepObservation{
+						BlockKey: ktypes.BlockKey("1"),
+						UpkeepIdentifiers: []ktypes.UpkeepIdentifier{
+							ktypes.UpkeepIdentifier("2"),
+						},
+					})),
+				},
 			},
 			FilterOut: []ktypes.UpkeepKey{
 				chain.UpkeepKey("1|1"),
@@ -349,9 +456,31 @@ func TestReport(t *testing.T) {
 			ReportGasLimit: 10000000,
 			Ctx:            func() (context.Context, func()) { return context.Background(), func() {} },
 			Observations: []types.AttributedObservation{
-				{Observation: types.Observation(mustEncodeKeys([]ktypes.UpkeepKey{chain.UpkeepKey("1|2")}))},
-				{Observation: types.Observation(mustEncodeKeys([]ktypes.UpkeepKey{chain.UpkeepKey("1|1"), chain.UpkeepKey("1|2")}))},
-				{Observation: types.Observation(mustEncodeKeys([]ktypes.UpkeepKey{chain.UpkeepKey("1|2")}))},
+				{Observation: types.Observation(mustEncodeUpkeepObservation(
+					&ktypes.UpkeepObservation{
+						BlockKey: ktypes.BlockKey("1"),
+						UpkeepIdentifiers: []ktypes.UpkeepIdentifier{
+							ktypes.UpkeepIdentifier("2"),
+						},
+					})),
+				},
+				{Observation: types.Observation(mustEncodeUpkeepObservation(
+					&ktypes.UpkeepObservation{
+						BlockKey: ktypes.BlockKey("1"),
+						UpkeepIdentifiers: []ktypes.UpkeepIdentifier{
+							ktypes.UpkeepIdentifier("1"),
+							ktypes.UpkeepIdentifier("2"),
+						},
+					})),
+				},
+				{Observation: types.Observation(mustEncodeUpkeepObservation(
+					&ktypes.UpkeepObservation{
+						BlockKey: ktypes.BlockKey("1"),
+						UpkeepIdentifiers: []ktypes.UpkeepIdentifier{
+							ktypes.UpkeepIdentifier("2"),
+						},
+					})),
+				},
 			},
 			Checks: checks{
 				K: []ktypes.UpkeepKey{
@@ -370,9 +499,9 @@ func TestReport(t *testing.T) {
 			ReportGasLimit: 10000000,
 			Ctx:            func() (context.Context, func()) { return context.Background(), func() {} },
 			Observations: []types.AttributedObservation{
-				{Observation: types.Observation(mustEncodeKeys([]ktypes.UpkeepKey{}))},
-				{Observation: types.Observation(mustEncodeKeys([]ktypes.UpkeepKey{}))},
-				{Observation: types.Observation(mustEncodeKeys([]ktypes.UpkeepKey{}))},
+				{Observation: types.Observation(mustEncodeUpkeepObservation(&ktypes.UpkeepObservation{}))},
+				{Observation: types.Observation(mustEncodeUpkeepObservation(&ktypes.UpkeepObservation{}))},
+				{Observation: types.Observation(mustEncodeUpkeepObservation(&ktypes.UpkeepObservation{}))},
 			},
 			Checks: checks{
 				K: []ktypes.UpkeepKey{},
@@ -393,9 +522,30 @@ func TestReport(t *testing.T) {
 			ReportGasLimit: 10000000,
 			Ctx:            func() (context.Context, func()) { return context.Background(), func() {} },
 			Observations: []types.AttributedObservation{
-				{Observation: types.Observation(mustEncodeKeys([]ktypes.UpkeepKey{chain.UpkeepKey([]byte("1|1"))}))},
-				{Observation: types.Observation(mustEncodeKeys([]ktypes.UpkeepKey{chain.UpkeepKey([]byte("1|1"))}))},
-				{Observation: types.Observation(mustEncodeKeys([]ktypes.UpkeepKey{chain.UpkeepKey([]byte("1|1"))}))},
+				{Observation: types.Observation(mustEncodeUpkeepObservation(
+					&ktypes.UpkeepObservation{
+						BlockKey: ktypes.BlockKey("1"),
+						UpkeepIdentifiers: []ktypes.UpkeepIdentifier{
+							ktypes.UpkeepIdentifier("1"),
+						},
+					})),
+				},
+				{Observation: types.Observation(mustEncodeUpkeepObservation(
+					&ktypes.UpkeepObservation{
+						BlockKey: ktypes.BlockKey("1"),
+						UpkeepIdentifiers: []ktypes.UpkeepIdentifier{
+							ktypes.UpkeepIdentifier("1"),
+						},
+					})),
+				},
+				{Observation: types.Observation(mustEncodeUpkeepObservation(
+					&ktypes.UpkeepObservation{
+						BlockKey: ktypes.BlockKey("1"),
+						UpkeepIdentifiers: []ktypes.UpkeepIdentifier{
+							ktypes.UpkeepIdentifier("1"),
+						},
+					})),
+				},
 			},
 			Checks: checks{
 				K: []ktypes.UpkeepKey{

--- a/internal/keepers/ocr_test.go
+++ b/internal/keepers/ocr_test.go
@@ -49,17 +49,20 @@ func TestObservation(t *testing.T) {
 		ExpectedErr         error
 	}{
 		{
-			Name:                "Empty Set",
-			Ctx:                 func() (context.Context, func()) { return context.Background(), func() {} },
-			SampleSet:           ktypes.UpkeepResults{},
-			ExpectedObservation: types.Observation(mustEncodeKeys([]ktypes.UpkeepKey{})),
+			Name:      "Empty Set",
+			Ctx:       func() (context.Context, func()) { return context.Background(), func() {} },
+			SampleSet: ktypes.UpkeepResults{},
+			ExpectedObservation: types.Observation(mustEncodeUpkeepObservation(&ktypes.UpkeepObservation{
+				UpkeepIdentifiers: []ktypes.UpkeepIdentifier{},
+			})),
 		},
 		{
-			Name:                "Timer Context",
-			Ctx:                 func() (context.Context, func()) { return context.WithTimeout(context.Background(), time.Second) },
-			SampleSet:           ktypes.UpkeepResults{},
-			ExpectedObservation: types.Observation(mustEncodeKeys([]ktypes.UpkeepKey{})),
-		},
+			Name:      "Timer Context",
+			Ctx:       func() (context.Context, func()) { return context.WithTimeout(context.Background(), time.Second) },
+			SampleSet: ktypes.UpkeepResults{},
+			ExpectedObservation: types.Observation(mustEncodeUpkeepObservation(&ktypes.UpkeepObservation{
+				UpkeepIdentifiers: []ktypes.UpkeepIdentifier{},
+			}))},
 		{
 			Name:                "Upkeep Service Error",
 			Ctx:                 func() (context.Context, func()) { return context.Background(), func() {} },
@@ -75,7 +78,9 @@ func TestObservation(t *testing.T) {
 				{Key: chain.UpkeepKey("1|1"), State: ktypes.NotEligible},
 				{Key: chain.UpkeepKey("1|2"), State: ktypes.NotEligible},
 			},
-			ExpectedObservation: types.Observation(mustEncodeKeys([]ktypes.UpkeepKey{})),
+			ExpectedObservation: types.Observation(mustEncodeUpkeepObservation(&ktypes.UpkeepObservation{
+				UpkeepIdentifiers: []ktypes.UpkeepIdentifier{},
+			})),
 		},
 		{
 			Name: "Filter to Non-empty Set",
@@ -84,7 +89,12 @@ func TestObservation(t *testing.T) {
 				{Key: chain.UpkeepKey([]byte("1|1")), State: ktypes.NotEligible},
 				{Key: chain.UpkeepKey([]byte("1|2")), State: ktypes.Eligible},
 			},
-			ExpectedObservation: types.Observation(mustEncodeKeys([]ktypes.UpkeepKey{chain.UpkeepKey("1|2")})),
+			ExpectedObservation: types.Observation(mustEncodeUpkeepObservation(&ktypes.UpkeepObservation{
+				BlockKey: "1",
+				UpkeepIdentifiers: []ktypes.UpkeepIdentifier{
+					ktypes.UpkeepIdentifier("2"),
+				},
+			})),
 		},
 		{
 			Name: "Reduce Key List to Observation Limit",
@@ -101,14 +111,27 @@ func TestObservation(t *testing.T) {
 				{Key: chain.UpkeepKey([]byte("100000000000100000000000100000000000100000000000100000000001|100000000000100000000000100000000000100000000009")), State: ktypes.Eligible},
 				{Key: chain.UpkeepKey([]byte("100000000000100000000000100000000000100000000000100000000001|100000000000100000000000100000000000100000000010")), State: ktypes.Eligible},
 				{Key: chain.UpkeepKey([]byte("100000000000100000000000100000000000100000000000100000000001|100000000000100000000000100000000000100000000011")), State: ktypes.Eligible},
+				{Key: chain.UpkeepKey([]byte("100000000000100000000000100000000000100000000000100000000001|100000000000100000000000100000000000100000000012")), State: ktypes.Eligible},
+				{Key: chain.UpkeepKey([]byte("100000000000100000000000100000000000100000000000100000000001|100000000000100000000000100000000000100000000013")), State: ktypes.Eligible},
+				{Key: chain.UpkeepKey([]byte("100000000000100000000000100000000000100000000000100000000001|100000000000100000000000100000000000100000000014")), State: ktypes.Eligible},
+				{Key: chain.UpkeepKey([]byte("100000000000100000000000100000000000100000000000100000000001|100000000000100000000000100000000000100000000015")), State: ktypes.Eligible},
 			},
-			ExpectedObservation: types.Observation(mustEncodeKeys([]ktypes.UpkeepKey{
-				chain.UpkeepKey([]byte("100000000000100000000000100000000000100000000000100000000001|100000000000100000000000100000000000100000000001")),
-				chain.UpkeepKey([]byte("100000000000100000000000100000000000100000000000100000000001|100000000000100000000000100000000000100000000002")),
-				chain.UpkeepKey([]byte("100000000000100000000000100000000000100000000000100000000001|100000000000100000000000100000000000100000000003")),
-				chain.UpkeepKey([]byte("100000000000100000000000100000000000100000000000100000000001|100000000000100000000000100000000000100000000004")),
-				chain.UpkeepKey([]byte("100000000000100000000000100000000000100000000000100000000001|100000000000100000000000100000000000100000000005")),
-				chain.UpkeepKey([]byte("100000000000100000000000100000000000100000000000100000000001|100000000000100000000000100000000000100000000006")),
+			ExpectedObservation: types.Observation(mustEncodeUpkeepObservation(&ktypes.UpkeepObservation{
+				BlockKey: "100000000000100000000000100000000000100000000000100000000001",
+				UpkeepIdentifiers: []ktypes.UpkeepIdentifier{
+					ktypes.UpkeepIdentifier("100000000000100000000000100000000000100000000001"),
+					ktypes.UpkeepIdentifier("100000000000100000000000100000000000100000000002"),
+					ktypes.UpkeepIdentifier("100000000000100000000000100000000000100000000003"),
+					ktypes.UpkeepIdentifier("100000000000100000000000100000000000100000000004"),
+					ktypes.UpkeepIdentifier("100000000000100000000000100000000000100000000005"),
+					ktypes.UpkeepIdentifier("100000000000100000000000100000000000100000000006"),
+					ktypes.UpkeepIdentifier("100000000000100000000000100000000000100000000007"),
+					ktypes.UpkeepIdentifier("100000000000100000000000100000000000100000000008"),
+					ktypes.UpkeepIdentifier("100000000000100000000000100000000000100000000009"),
+					ktypes.UpkeepIdentifier("100000000000100000000000100000000000100000000010"),
+					ktypes.UpkeepIdentifier("100000000000100000000000100000000000100000000011"),
+					ktypes.UpkeepIdentifier("100000000000100000000000100000000000100000000012"),
+				},
 			})),
 		},
 	}
@@ -891,6 +914,11 @@ func (_m *BenchmarkMockUpkeepService) IsUpkeepLocked(ctx context.Context, key kt
 
 func mustEncodeKeys(keys []ktypes.UpkeepKey) []byte {
 	b, _ := encode(keys)
+	return b
+}
+
+func mustEncodeUpkeepObservation(o *ktypes.UpkeepObservation) []byte {
+	b, _ := encode(o)
 	return b
 }
 

--- a/internal/keepers/util.go
+++ b/internal/keepers/util.go
@@ -309,7 +309,8 @@ func limitedLengthEncode(obs *ktypes.UpkeepObservation, limit int) ([]byte, erro
 	var err error
 
 	emptyObservation := &ktypes.UpkeepObservation{
-		BlockKey: obs.BlockKey,
+		BlockKey:          obs.BlockKey,
+		UpkeepIdentifiers: []ktypes.UpkeepIdentifier{},
 	}
 
 	b, err = encode(emptyObservation)

--- a/internal/keepers/util_test.go
+++ b/internal/keepers/util_test.go
@@ -292,12 +292,12 @@ func FuzzLimitedLengthEncode(f *testing.F) {
 
 		if a > 0 {
 			output := make([]ktypes.UpkeepKey, 0)
-			outputKeys := make([]chain.UpkeepKey, 0)
-			err = decode(bt, &outputKeys)
+			obs := &ktypes.UpkeepObservation{}
+			err = decode(bt, obs)
 			assert.NoError(t, err)
 
-			for _, o := range outputKeys {
-				output = append(output, o)
+			for _, o := range obs.UpkeepIdentifiers {
+				output = append(output, chain.NewUpkeepKeyFromBlockAndID(obs.BlockKey, o))
 			}
 
 			assert.Greater(t, len(bt), 0, "length of bytes :: keys: %d; length: %d", a, b)

--- a/pkg/chain/upkeep_key.go
+++ b/pkg/chain/upkeep_key.go
@@ -16,6 +16,10 @@ func NewUpkeepKey(block, id *big.Int) UpkeepKey {
 	return UpkeepKey(fmt.Sprintf("%s%s%s", block, separator, id))
 }
 
+func NewUpkeepKeyFromBlockAndID(block types.BlockKey, id types.UpkeepIdentifier) UpkeepKey {
+	return UpkeepKey(fmt.Sprintf("%s%s%s", string(block), separator, string(id)))
+}
+
 func (u UpkeepKey) BlockKeyAndUpkeepID() (types.BlockKey, types.UpkeepIdentifier, error) {
 	components := strings.Split(u.String(), "|")
 	if len(components) != 2 {

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -68,6 +68,11 @@ type BlockKey string
 
 type Address []byte
 
+type UpkeepObservation struct {
+	BlockKey          BlockKey           `json:"blockKey"`
+	UpkeepIdentifiers []UpkeepIdentifier `json:"upkeepIdentifiers"`
+}
+
 // UpkeepKey is an identifier of an upkeep at a moment in time, typically an
 // upkeep at a block number
 type UpkeepKey interface {


### PR DESCRIPTION
In this PR, I'm adding a new UpkeepObservation type that encodes a block key and a list of upkeep identifiers

The UpkeepObservation is emitted by the observation phase and consumed by the report phase

Previously, we emitted and consumed a list of upkeep keys

To better illustrate this, before, we had:

```[1|567, 1|999, 1|2000]```

Now we have:

```{
"blockKey": "1",
"upkeepIdentifiers": ["567", "999", "2000"]
}```

The key areas impacted by this change are:

- Limited length encoding
- OCR tests
- shuffledDedupedKeyList