### PR TITLE
Minor cleanup of types

### DIFF
--- a/cmd/simv2/simulators/contract.go
+++ b/cmd/simv2/simulators/contract.go
@@ -168,7 +168,11 @@ func (ct *SimulatedContract) run() {
 							Confirmations: 0,
 						}
 
-						id, _ := ct.IdentifierFromKey(result.Key)
+						_, id, err := result.Key.BlockKeyAndUpkeepID()
+						if err != nil {
+							continue
+						}
+
 						up, ok := ct.upkeeps[string(id)]
 						if ok {
 							//result.PerformData

--- a/cmd/simv2/simulators/registry.go
+++ b/cmd/simv2/simulators/registry.go
@@ -145,11 +145,3 @@ func (ct *SimulatedContract) CheckUpkeep(ctx context.Context, keys ...types.Upke
 
 	return results, nil
 }
-
-func (ct *SimulatedContract) IdentifierFromKey(key types.UpkeepKey) (types.UpkeepIdentifier, error) {
-	_, upkeepID, err := key.BlockKeyAndUpkeepID()
-	if err != nil {
-		panic(err.Error())
-	}
-	return upkeepID, nil
-}

--- a/internal/keepers/filter_test.go
+++ b/internal/keepers/filter_test.go
@@ -45,10 +45,8 @@ func TestReportCoordinator(t *testing.T) {
 
 		// calling filter at this point should return true because the key has not
 		// yet been added to the filter
-		mr.Mock.On("IdentifierFromKey", key1Block1).Return(id1, nil)
 		assert.Equal(t, true, filter(key1Block1), "should not filter out key 1 at block 1: key has not been accepted")
 
-		mr.Mock.On("IdentifierFromKey", key1Block2).Return(id1, nil)
 		assert.Equal(t, true, filter(key1Block2), "should not filter out key 1 at block 2: key has not been accepted")
 
 		// is transmission confirmed should also return true because the key has
@@ -62,7 +60,6 @@ func TestReportCoordinator(t *testing.T) {
 	t.Run("Accept", func(t *testing.T) {
 		rc, mr, _ := setup(t, log.New(io.Discard, "nil", 0))
 
-		mr.Mock.On("IdentifierFromKey", key1Block1).Return(id1, nil)
 		assert.NoError(t, rc.Accept(key1Block1), "no error expected from accepting the key")
 		assert.ErrorIs(t, rc.Accept(key1Block1), ErrKeyAlreadyAccepted, "key should not be accepted again and should return an error")
 
@@ -73,15 +70,12 @@ func TestReportCoordinator(t *testing.T) {
 		rc, mr, _ := setup(t, log.New(io.Discard, "nil", 0))
 		filter := rc.Filter()
 
-		mr.Mock.On("IdentifierFromKey", key1Block1).Return(id1, nil)
 		_ = rc.Accept(key1Block1)
 
 		// no logs have been read at this point so the upkeep key should be filtered
 		// out at all block numbers
-		mr.Mock.On("IdentifierFromKey", key1Block1).Return(id1, nil)
 		assert.Equal(t, false, filter(key1Block1), "filter should return false to indicate key should be filtered out at block 1")
 
-		mr.Mock.On("IdentifierFromKey", key1Block2).Return(id1, nil)
 		assert.Equal(t, false, filter(key1Block2), "filter should return false to indicate key should be filtered out at block 2")
 
 		assert.Equal(t, false, rc.IsTransmissionConfirmed(key1Block1), "transmit should not be confirmed: key is now set, but no logs have been identified")
@@ -96,10 +90,8 @@ func TestReportCoordinator(t *testing.T) {
 		rc, mr, mp := setup(t, log.New(io.Discard, "nil", 0))
 		filter := rc.Filter()
 
-		mr.Mock.On("IdentifierFromKey", key1Block1).Return(id1, nil)
 		_ = rc.Accept(key1Block1)
 
-		mr.Mock.On("IdentifierFromKey", key1Block1).Return(id1, nil)
 		mp.Mock.On("PerformLogs", mock.Anything).Return([]types.PerformLog{
 			{Key: key1Block1, TransmitBlock: bk2, Confirmations: 0},
 		}, nil).Once()
@@ -108,10 +100,8 @@ func TestReportCoordinator(t *testing.T) {
 
 		// perform log didn't have the threshold number of confirmations
 		// making the key still locked at all blocks
-		mr.Mock.On("IdentifierFromKey", key1Block1).Return(id1, nil)
 		assert.Equal(t, false, filter(key1Block1), "filter should return false to indicate key should be filtered out at block 1")
 
-		mr.Mock.On("IdentifierFromKey", key1Block2).Return(id1, nil)
 		assert.Equal(t, false, filter(key1Block2), "filter should return false to indicate key should be filtered out at block 2")
 
 		assert.Equal(t, false, rc.IsTransmissionConfirmed(key1Block1), "transmit should not be confirmed: the key is now set, but no logs have been identified")
@@ -125,10 +115,8 @@ func TestReportCoordinator(t *testing.T) {
 		rc, mr, mp := setup(t, log.New(io.Discard, "nil", 0))
 		filter := rc.Filter()
 
-		mr.Mock.On("IdentifierFromKey", key1Block1).Return(id1, nil)
 		_ = rc.Accept(key1Block1)
 
-		mr.Mock.On("IdentifierFromKey", key1Block1).Return(id1, nil)
 		mp.Mock.On("PerformLogs", mock.Anything).Return([]types.PerformLog{
 			{Key: key1Block1, TransmitBlock: bk2, Confirmations: 1},
 		}, nil).Once()
@@ -137,13 +125,10 @@ func TestReportCoordinator(t *testing.T) {
 
 		// because the transmit block is block 2, the filter should continue
 		// to filter out key up to block 2
-		mr.Mock.On("IdentifierFromKey", key1Block1).Return(id1, nil)
 		assert.Equal(t, false, filter(key1Block1), "filter should return false to indicate key should be filtered out at block 1")
 
-		mr.Mock.On("IdentifierFromKey", key1Block2).Return(id1, nil)
 		assert.Equal(t, false, filter(key1Block2), "filter should return false to indicate key should be filtered out at block 2")
 
-		mr.Mock.On("IdentifierFromKey", key1Block3).Return(id1, nil)
 		assert.Equal(t, true, filter(key1Block3), "filter should return true to indicate key should not be filtered out at block 3")
 
 		assert.Equal(t, true, rc.IsTransmissionConfirmed(key1Block1), "transmit should be confirmed")
@@ -160,31 +145,29 @@ func TestReportCoordinator(t *testing.T) {
 		filter := rc.Filter()
 
 		// 1. key 1|1 is Accepted
-		mr.Mock.On("IdentifierFromKey", key1Block1).Return(id1, nil)
 		_ = rc.Accept(key1Block1)
 
 		// 1a. key 1|1 filter returns false
 		// 1c. key 2|1 filter returns false
 		// 1d. key 4|1 filter returns false
 		// reason: the node sees id 1 as 'in-flight' and blocks for all block numbers
-		assertFilter(t, mr, key1Block1, id1, false, filter)
-		assertFilter(t, mr, key1Block2, id1, false, filter)
-		assertFilter(t, mr, key1Block4, id1, false, filter)
+		assertFilter(t, key1Block1, false, filter)
+		assertFilter(t, key1Block2, false, filter)
+		assertFilter(t, key1Block4, false, filter)
 
 		// 1b. key 1|1 transmit confirmed returns false
 		assert.Equal(t, false, rc.IsTransmissionConfirmed(key1Block1), "1|1 transmit should not be confirmed")
 
 		// 2. key 2|1 is Accepted (if other nodes produce report)
-		mr.Mock.On("IdentifierFromKey", key1Block1).Return(id1, nil)
 		_ = rc.Accept(key1Block2)
 
 		// 2a. key 1|1 filter returns false
 		// 2c. key 2|1 filter returns false
 		// 2e. key 4|1 filter returns false
 		// reason: the node still sees id 1 as 'in-flight' and blocks for all block numbers
-		assertFilter(t, mr, key1Block1, id1, false, filter)
-		assertFilter(t, mr, key1Block2, id1, false, filter)
-		assertFilter(t, mr, key1Block4, id1, false, filter)
+		assertFilter(t, key1Block1, false, filter)
+		assertFilter(t, key1Block2, false, filter)
+		assertFilter(t, key1Block4, false, filter)
 
 		// 2b. key 1|1 transmit confirmed returns false
 		// 2d. key 2|1 transmit confirmed returns false
@@ -192,7 +175,6 @@ func TestReportCoordinator(t *testing.T) {
 		assert.Equal(t, false, rc.IsTransmissionConfirmed(key1Block2), "2|1 transmit should not be confirmed")
 
 		// 3. perform log for 1|1 is at block 2
-		mr.Mock.On("IdentifierFromKey", key1Block1).Return(id1, nil)
 		mp.Mock.On("PerformLogs", mock.Anything).Return([]types.PerformLog{
 			{Key: key1Block1, TransmitBlock: bk2, Confirmations: 1},
 		}, nil).Once()
@@ -203,9 +185,9 @@ func TestReportCoordinator(t *testing.T) {
 		// 3c. key 2|1 filter returns false
 		// 3e. key 4|1 filter returns false
 		// reason: the node still sees id 1 as 'in-flight' and blocks for all block numbers
-		assertFilter(t, mr, key1Block1, id1, false, filter)
-		assertFilter(t, mr, key1Block2, id1, false, filter)
-		assertFilter(t, mr, key1Block4, id1, false, filter)
+		assertFilter(t, key1Block1, false, filter)
+		assertFilter(t, key1Block2, false, filter)
+		assertFilter(t, key1Block4, false, filter)
 
 		// 3b. key 1|1 transmit confirmed returns true
 		// 3d. key 2|1 transmit confirmed returns false
@@ -214,7 +196,6 @@ func TestReportCoordinator(t *testing.T) {
 		assert.Equal(t, false, rc.IsTransmissionConfirmed(key1Block2), "2|1 transmit should not be confirmed")
 
 		// 4. perform log for 2|1 is at block 3
-		mr.Mock.On("IdentifierFromKey", key1Block2).Return(id1, nil)
 		mp.Mock.On("PerformLogs", mock.Anything).Return([]types.PerformLog{
 			{Key: key1Block2, TransmitBlock: bk3, Confirmations: 1},
 		}, nil).Once()
@@ -225,9 +206,9 @@ func TestReportCoordinator(t *testing.T) {
 		// 4c. key 2|1 filter returns false
 		// 4e. key 4|1 filter returns true
 		// reason: the id unblocks after the highest block number seen
-		assertFilter(t, mr, key1Block1, id1, false, filter)
-		assertFilter(t, mr, key1Block2, id1, false, filter)
-		assertFilter(t, mr, key1Block4, id1, true, filter)
+		assertFilter(t, key1Block1, false, filter)
+		assertFilter(t, key1Block2, false, filter)
+		assertFilter(t, key1Block4, true, filter)
 
 		// 4b. key 1|1 transmit confirmed returns true
 		// 4d. key 2|1 transmit confirmed returns true
@@ -247,14 +228,12 @@ func TestReportCoordinator(t *testing.T) {
 			TransmitBlockNumber: bk15,
 		}, util.DefaultCacheExpiration)
 
-		mr.Mock.On("IdentifierFromKey", key1Block4).Return(id1, nil)
 		assert.False(t, filter(key1Block4))
 
 		mr.AssertExpectations(t)
 	})
 }
 
-func assertFilter(t *testing.T, reg *types.MockRegistry, key types.UpkeepKey, id types.UpkeepIdentifier, exp bool, f func(types.UpkeepKey) bool) {
-	reg.Mock.On("IdentifierFromKey", key).Return(id, nil)
+func assertFilter(t *testing.T, key types.UpkeepKey, exp bool, f func(types.UpkeepKey) bool) {
 	assert.Equal(t, exp, f(key), "filter should return '%v' to indicate key should not be filtered out at block %s", exp, key)
 }

--- a/internal/keepers/ocr_test.go
+++ b/internal/keepers/ocr_test.go
@@ -1172,7 +1172,6 @@ func (_m *BenchmarkMockedReportEncoder) DecodeReport(report []byte) ([]ktypes.Up
 type BenchmarkMockedRegistry struct {
 	rtnKeys []ktypes.UpkeepKey
 	rtnRes  ktypes.UpkeepResult
-	rtnId   ktypes.UpkeepIdentifier
 }
 
 func (_m *BenchmarkMockedRegistry) GetActiveUpkeepKeys(ctx context.Context, key ktypes.BlockKey) ([]ktypes.UpkeepKey, error) {

--- a/internal/keepers/ocr_test.go
+++ b/internal/keepers/ocr_test.go
@@ -1183,10 +1183,6 @@ func (_m *BenchmarkMockedRegistry) CheckUpkeep(ctx context.Context, keys ...ktyp
 	return true, _m.rtnRes, nil
 }
 
-func (_m *BenchmarkMockedRegistry) IdentifierFromKey(key ktypes.UpkeepKey) (ktypes.UpkeepIdentifier, error) {
-	return _m.rtnId, nil
-}
-
 type BenchmarkMockedFilterer struct{}
 
 func (_m *BenchmarkMockedFilterer) Filter() func(ktypes.UpkeepKey) bool {

--- a/internal/keepers/service_test.go
+++ b/internal/keepers/service_test.go
@@ -73,9 +73,6 @@ func Test_onDemandUpkeepService_CheckUpkeep(t *testing.T) {
 		ctx, cancel := test.Ctx()
 
 		rg := ktypes.NewMockRegistry(t)
-		rg.Mock.On("IdentifierFromKey", mock.Anything).
-			Return(test.ID, nil).
-			Maybe()
 		rg.Mock.On("CheckUpkeep", mock.Anything, test.Key).
 			Return(test.RegResult, test.Err)
 

--- a/internal/keepers/util.go
+++ b/internal/keepers/util.go
@@ -139,12 +139,6 @@ func observationsToUpkeepKeys(logger *log.Logger, observations []types.Attribute
 			continue
 		}
 
-		if err := upkeepObservation.Validate(); err != nil {
-			logger.Printf("unable to validate observation: %s", err.Error())
-			parseErrors++
-			continue
-		}
-
 		blockKeyInt, ok := big.NewInt(0).SetString(upkeepObservation.BlockKey.String(), 10)
 		if !ok {
 			parseErrors++

--- a/internal/keepers/util_test.go
+++ b/internal/keepers/util_test.go
@@ -357,15 +357,17 @@ func FuzzLimitedLengthEncode(f *testing.F) {
 			return
 		}
 
+		blockKey := chain.BlockKey("123")
 		keys := make([]ktypes.UpkeepIdentifier, a)
 		for i := 0; i < a; i++ {
 			k := strings.Repeat("1", rand.Intn(b)+3)
-			k = k[:1] + "|" + k[2:]
 			keys[i] = ktypes.UpkeepIdentifier(k)
 		}
 
-		ob := &chain.UpkeepObservation{}
-		ob.UpkeepIdentifiers = keys
+		ob := &chain.UpkeepObservation{
+			BlockKey:          blockKey,
+			UpkeepIdentifiers: keys,
+		}
 		bt, err := limitedLengthEncode(ob, 1000)
 
 		assert.NoError(t, err)

--- a/pkg/chain/block_key.go
+++ b/pkg/chain/block_key.go
@@ -27,3 +27,7 @@ func (k BlockKey) After(kk types.BlockKey) (bool, error) {
 func (k BlockKey) String() string {
 	return string(k)
 }
+
+func (k BlockKey) BigInt() (*big.Int, bool) {
+	return big.NewInt(0).SetString(string(k), 10)
+}

--- a/pkg/chain/evmregistry.go
+++ b/pkg/chain/evmregistry.go
@@ -283,15 +283,6 @@ func (r *evmRegistryv2_0) CheckUpkeep(ctx context.Context, keys ...types.UpkeepK
 	}
 }
 
-func (r *evmRegistryv2_0) IdentifierFromKey(key types.UpkeepKey) (types.UpkeepIdentifier, error) {
-	_, id, err := key.BlockKeyAndUpkeepID()
-	if err != nil {
-		return nil, err
-	}
-
-	return id, nil
-}
-
 func (r *evmRegistryv2_0) buildCallOpts(ctx context.Context, block types.BlockKey) (*bind.CallOpts, error) {
 	b := new(big.Int)
 	_, ok := b.SetString(block.String(), 10)

--- a/pkg/chain/upkeep_key.go
+++ b/pkg/chain/upkeep_key.go
@@ -1,7 +1,6 @@
 package chain
 
 import (
-	"encoding/json"
 	"fmt"
 	"math/big"
 	"strings"
@@ -32,36 +31,4 @@ func (u UpkeepKey) BlockKeyAndUpkeepID() (types.BlockKey, types.UpkeepIdentifier
 
 func (u UpkeepKey) String() string {
 	return string(u)
-}
-
-func (u *UpkeepKey) UnmarshalJSON(b []byte) error {
-	var key []uint8
-	if err := json.Unmarshal(b, &key); err != nil {
-		return err
-	}
-
-	if !u.isValid(string(key)) {
-		return ErrUpkeepKeyNotParsable
-	}
-
-	*u = UpkeepKey(key)
-
-	return nil
-}
-
-func (u *UpkeepKey) isValid(v string) bool {
-	if strings.Count(v, separator) != 1 {
-		return false
-	}
-
-	components := strings.Split(v, separator)
-	if len(components) != 2 {
-		return false
-	}
-
-	if components[0] == "" || components[1] == "" {
-		return false
-	}
-
-	return true
 }

--- a/pkg/chain/upkeep_observation.go
+++ b/pkg/chain/upkeep_observation.go
@@ -1,6 +1,7 @@
 package chain
 
 import (
+	"encoding/json"
 	"fmt"
 	"math/big"
 
@@ -18,7 +19,24 @@ type UpkeepObservation struct {
 	UpkeepIdentifiers []types.UpkeepIdentifier `json:"2"`
 }
 
-func (uo UpkeepObservation) Validate() error {
+type upkeepObservation UpkeepObservation
+
+func (u *UpkeepObservation) UnmarshalJSON(b []byte) error {
+	var upkeep upkeepObservation
+	if err := json.Unmarshal(b, &upkeep); err != nil {
+		return err
+	}
+
+	if err := u.validate(upkeep); err != nil {
+		return err
+	}
+
+	*u = UpkeepObservation(upkeep)
+
+	return nil
+}
+
+func (u *UpkeepObservation) validate(uo upkeepObservation) error {
 	bl, ok := big.NewInt(0).SetString(uo.BlockKey.String(), 10)
 	if !ok {
 		return ErrBlockKeyNotParsable

--- a/pkg/types/registry.generated.go
+++ b/pkg/types/registry.generated.go
@@ -67,29 +67,6 @@ func (_m *MockRegistry) GetActiveUpkeepIDs(_a0 context.Context) ([]UpkeepIdentif
 	return r0, r1
 }
 
-// IdentifierFromKey provides a mock function with given fields: _a0
-func (_m *MockRegistry) IdentifierFromKey(_a0 UpkeepKey) (UpkeepIdentifier, error) {
-	ret := _m.Called(_a0)
-
-	var r0 UpkeepIdentifier
-	if rf, ok := ret.Get(0).(func(UpkeepKey) UpkeepIdentifier); ok {
-		r0 = rf(_a0)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(UpkeepIdentifier)
-		}
-	}
-
-	var r1 error
-	if rf, ok := ret.Get(1).(func(UpkeepKey) error); ok {
-		r1 = rf(_a0)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
 // NewMockRegistry creates a new instance of MockRegistry. It also registers the testing.TB interface on the mock and a cleanup function to assert the mocks expectations.
 func NewMockRegistry(t testing.TB) *MockRegistry {
 	mock := &MockRegistry{}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -38,7 +38,6 @@ type EVMClient interface {
 type Registry interface {
 	GetActiveUpkeepIDs(context.Context) ([]UpkeepIdentifier, error)
 	CheckUpkeep(context.Context, ...UpkeepKey) (UpkeepResults, error)
-	IdentifierFromKey(UpkeepKey) (UpkeepIdentifier, error)
 }
 
 // ReportEncoder represents the report encoder behaviour
@@ -66,6 +65,7 @@ type PerformLog struct {
 
 type BlockKey interface {
 	After(BlockKey) (bool, error)
+	BigInt() (*big.Int, bool)
 	fmt.Stringer
 }
 


### PR DESCRIPTION
Drop IdentifierFromKey from the Registry interface
Add a BigInt function to the BlockKey type
Trigger UpkeepObservation validation when unmarshaling