### PR TITLE
AUTO-2152: Upkeep id manipulation

### DIFF
--- a/internal/keepers/factory.go
+++ b/internal/keepers/factory.go
@@ -143,7 +143,6 @@ func (d *keepersReportingFactory) NewReportingPlugin(c types.ReportingPluginConf
 			malicious.SendZeroUpkeepID,
 			malicious.SendVeryLargeUpkeepIDs,
 			malicious.SendLeadingZeroUpkeepIDs,
-			malicious.SendLeadingZeroUpkeepIDsSameBlock,
 		},
 	}, info, nil
 }

--- a/internal/keepers/factory.go
+++ b/internal/keepers/factory.go
@@ -142,6 +142,8 @@ func (d *keepersReportingFactory) NewReportingPlugin(c types.ReportingPluginConf
 			malicious.SendNegativeUpkeepID,
 			malicious.SendZeroUpkeepID,
 			malicious.SendVeryLargeUpkeepIDs,
+			malicious.SendLeadingZeroUpkeepIDs,
+			malicious.SendLeadingZeroUpkeepIDsSameBlock,
 		},
 	}, info, nil
 }

--- a/internal/keepers/factory.go
+++ b/internal/keepers/factory.go
@@ -139,6 +139,9 @@ func (d *keepersReportingFactory) NewReportingPlugin(c types.ReportingPluginConf
 			malicious.SendZeroBlockNumber,
 			malicious.SendEmptyBlockValue,
 			malicious.SendVeryLargeBlockValue,
+			malicious.SendNegativeUpkeepID,
+			malicious.SendZeroUpkeepID,
+			malicious.SendVeryLargeUpkeepIDs,
 		},
 	}, info, nil
 }

--- a/internal/malicious/blocks.go
+++ b/internal/malicious/blocks.go
@@ -256,50 +256,12 @@ func SendLeadingZeroUpkeepIDs(ctx context.Context, original []byte, _ error) (st
 	}
 
 	var ids []types.UpkeepIdentifier
-	for i := 0; i < len(ob.UpkeepIdentifiers); i++ {
-		keyStr, err := GenerateRandomASCIIString(1000)
-		if err != nil {
-			return name, nil, err
-		}
-
-		ids = append(ids, types.UpkeepIdentifier(fmt.Sprintf("%s%s", strings.Repeat("0", rand2.Intn(100)), keyStr)))
+	for _, upkeepID := range ob.UpkeepIdentifiers {
+		ids = append(ids, types.UpkeepIdentifier(fmt.Sprintf("%s%s", strings.Repeat("0", rand2.Intn(100)), upkeepID)))
 	}
 
 	observation := modifiedObservation{
 		BlockKey:          ob.BlockKey,
-		UpkeepIdentifiers: ids,
-	}
-
-	b, err := json.Marshal(observation)
-	return name, b, err
-}
-
-// SendLeadingZeroUpkeepIDsSameBlock produces an encoded json object with upkeep IDs with leading zeroes for the same block key
-func SendLeadingZeroUpkeepIDsSameBlock(ctx context.Context, original []byte, _ error) (string, []byte, error) {
-	name := "Leading Zero Upkeep IDs With Same Block"
-
-	type modifiedObservation struct {
-		BlockKey          types.BlockKey           `json:"1"`
-		UpkeepIdentifiers []types.UpkeepIdentifier `json:"2"`
-	}
-
-	var ob chain.UpkeepObservation
-	if err := json.Unmarshal(original, &ob); err != nil {
-		return name, nil, err
-	}
-
-	var ids []types.UpkeepIdentifier
-	for i := 0; i < len(ob.UpkeepIdentifiers); i++ {
-		keyStr, err := GenerateRandomASCIIString(1000)
-		if err != nil {
-			return name, nil, err
-		}
-
-		ids = append(ids, types.UpkeepIdentifier(fmt.Sprintf("%s%s", strings.Repeat("0", rand2.Intn(100)), keyStr)))
-	}
-
-	observation := modifiedObservation{
-		BlockKey:          chain.BlockKey("100"),
 		UpkeepIdentifiers: ids,
 	}
 

--- a/internal/malicious/blocks.go
+++ b/internal/malicious/blocks.go
@@ -145,6 +145,100 @@ func SendVeryLargeBlockValue(ctx context.Context, original []byte, _ error) (str
 	return name, b, err
 }
 
+// SendNegativeUpkeepID produces an encoded json object with the upkeep IDs as negative values
+func SendNegativeUpkeepID(ctx context.Context, original []byte, _ error) (string, []byte, error) {
+	name := "Send Negative Upkeep ID"
+
+	type modifiedObservation struct {
+		BlockKey          types.BlockKey           `json:"1"`
+		UpkeepIdentifiers []types.UpkeepIdentifier `json:"2"`
+	}
+
+	var ob chain.UpkeepObservation
+	if err := json.Unmarshal(original, &ob); err != nil {
+		return name, nil, err
+	}
+
+	var ids []types.UpkeepIdentifier
+	for _, id := range ob.UpkeepIdentifiers {
+		idInt, _ := id.BigInt()
+		if idInt.Cmp(big.NewInt(0)) > 1 {
+			ids = append(ids, types.UpkeepIdentifier(idInt.Neg(idInt).String()))
+		} else {
+			ids = append(ids, id)
+		}
+	}
+
+	observation := modifiedObservation{
+		BlockKey:          ob.BlockKey,
+		UpkeepIdentifiers: ids,
+	}
+
+	b, err := json.Marshal(observation)
+	return name, b, err
+}
+
+// SendZeroUpkeepID produces an encoded json object with the upkeep IDs as zeroes
+func SendZeroUpkeepID(ctx context.Context, original []byte, _ error) (string, []byte, error) {
+	name := "Send Zero Upkeep ID"
+
+	type modifiedObservation struct {
+		BlockKey          types.BlockKey           `json:"1"`
+		UpkeepIdentifiers []types.UpkeepIdentifier `json:"2"`
+	}
+
+	var ob chain.UpkeepObservation
+	if err := json.Unmarshal(original, &ob); err != nil {
+		return name, nil, err
+	}
+
+	var ids []types.UpkeepIdentifier
+	for i := 0; i < len(ob.UpkeepIdentifiers); i++ {
+		ids = append(ids, types.UpkeepIdentifier("0"))
+	}
+
+	observation := modifiedObservation{
+		BlockKey:          ob.BlockKey,
+		UpkeepIdentifiers: ids,
+	}
+
+	b, err := json.Marshal(observation)
+	return name, b, err
+}
+
+// SendVeryLargeUpkeepIDs produces an encoded json object with very large upkeep IDs
+func SendVeryLargeUpkeepIDs(ctx context.Context, original []byte, _ error) (string, []byte, error) {
+	name := "Very Large Upkeep ID"
+
+	type modifiedObservation struct {
+		BlockKey          types.BlockKey           `json:"1"`
+		UpkeepIdentifiers []types.UpkeepIdentifier `json:"2"`
+	}
+
+	var ob chain.UpkeepObservation
+	if err := json.Unmarshal(original, &ob); err != nil {
+		return name, nil, err
+	}
+
+	var ids []types.UpkeepIdentifier
+	for i := 0; i < len(ob.UpkeepIdentifiers); i++ {
+		keyStr, err := GenerateRandomASCIIString(1000)
+		if err != nil {
+			return name, nil, err
+		}
+
+		ids = append(ids, types.UpkeepIdentifier(keyStr))
+	}
+
+	observation := modifiedObservation{
+		BlockKey:          ob.BlockKey,
+		UpkeepIdentifiers: ids,
+	}
+
+	b, err := json.Marshal(observation)
+	return name, b, err
+}
+
 func GenerateRandomASCIIString(length int) (string, error) {
 	result := strings.Builder{}
 	for {

--- a/internal/malicious/blocks.go
+++ b/internal/malicious/blocks.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/json"
+	"fmt"
 	"math/big"
+	rand2 "math/rand"
 	"strings"
 
 	"github.com/smartcontractkit/ocr2keepers/pkg/chain"
@@ -232,6 +234,72 @@ func SendVeryLargeUpkeepIDs(ctx context.Context, original []byte, _ error) (stri
 
 	observation := modifiedObservation{
 		BlockKey:          ob.BlockKey,
+		UpkeepIdentifiers: ids,
+	}
+
+	b, err := json.Marshal(observation)
+	return name, b, err
+}
+
+// SendLeadingZeroUpkeepIDs produces an encoded json object with upkeep IDs with leading zeroes
+func SendLeadingZeroUpkeepIDs(ctx context.Context, original []byte, _ error) (string, []byte, error) {
+	name := "Leading Zero Upkeep IDs With Different Block"
+
+	type modifiedObservation struct {
+		BlockKey          types.BlockKey           `json:"1"`
+		UpkeepIdentifiers []types.UpkeepIdentifier `json:"2"`
+	}
+
+	var ob chain.UpkeepObservation
+	if err := json.Unmarshal(original, &ob); err != nil {
+		return name, nil, err
+	}
+
+	var ids []types.UpkeepIdentifier
+	for i := 0; i < len(ob.UpkeepIdentifiers); i++ {
+		keyStr, err := GenerateRandomASCIIString(1000)
+		if err != nil {
+			return name, nil, err
+		}
+
+		ids = append(ids, types.UpkeepIdentifier(fmt.Sprintf("%s%s", strings.Repeat("0", rand2.Intn(100)), keyStr)))
+	}
+
+	observation := modifiedObservation{
+		BlockKey:          ob.BlockKey,
+		UpkeepIdentifiers: ids,
+	}
+
+	b, err := json.Marshal(observation)
+	return name, b, err
+}
+
+// SendLeadingZeroUpkeepIDsSameBlock produces an encoded json object with upkeep IDs with leading zeroes for the same block key
+func SendLeadingZeroUpkeepIDsSameBlock(ctx context.Context, original []byte, _ error) (string, []byte, error) {
+	name := "Leading Zero Upkeep IDs With Same Block"
+
+	type modifiedObservation struct {
+		BlockKey          types.BlockKey           `json:"1"`
+		UpkeepIdentifiers []types.UpkeepIdentifier `json:"2"`
+	}
+
+	var ob chain.UpkeepObservation
+	if err := json.Unmarshal(original, &ob); err != nil {
+		return name, nil, err
+	}
+
+	var ids []types.UpkeepIdentifier
+	for i := 0; i < len(ob.UpkeepIdentifiers); i++ {
+		keyStr, err := GenerateRandomASCIIString(1000)
+		if err != nil {
+			return name, nil, err
+		}
+
+		ids = append(ids, types.UpkeepIdentifier(fmt.Sprintf("%s%s", strings.Repeat("0", rand2.Intn(100)), keyStr)))
+	}
+
+	observation := modifiedObservation{
+		BlockKey:          chain.BlockKey("100"),
 		UpkeepIdentifiers: ids,
 	}
 


### PR DESCRIPTION
In this PR, I've added the following test cases:

- Node sending negative number as upkeep id
- Node sending 0 upkeep id
- Node sending upkeep id with 1000 or more digits
- Node sending multiple upkeep IDs with leading zeroes and different block numbers
- Node sending multiple upkeep IDs with leading zeroes and same block numbers