### PR TITLE
Move dependency checks to schedule

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -37,22 +37,6 @@ jobs:
     - name: Run Unit Tests
       run: go test -v ./...
 
-  dependency-check:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-
-    - name: Set up Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.19
-    
-    - name: Write Go Dep list
-      run: go list -json -m all > go.list
-    
-    - name: Nancy Scan
-      uses: sonatype-nexus-community/nancy-github-action@main
-    
   race-test:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/scheduled-dependency-check.yaml
+++ b/.github/workflows/scheduled-dependency-check.yaml
@@ -1,0 +1,22 @@
+name: Weekly Dependency Check
+
+on:
+  schedule:
+    - cron: '0 0 */7 * *'
+  
+jobs:
+  dependency-check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Go
+      uses: actions/setup-go@v3
+      with:
+        go-version: 1.19
+    
+    - name: Write Go Dep list
+      run: go list -json -m all > go.list
+    
+    - name: Nancy Scan
+      uses: sonatype-nexus-community/nancy-github-action@main


### PR DESCRIPTION
Dependency checks can be run on a schedule instead of as part of pull requests or pushes that block the pipeline. These will only be notifications so they should be monitored.