### PR TITLE
Correct observation list length comparison

### DIFF
--- a/internal/keepers/util.go
+++ b/internal/keepers/util.go
@@ -158,7 +158,12 @@ func observationsToUpkeepKeys(logger *log.Logger, observations []types.Attribute
 
 		// if we have a non-empty list of upkeep identifiers, limit the upkeeps we take to observationUpkeepsLimit
 		if len(upkeepObservation.UpkeepIdentifiers) > 0 {
-			upkeepIDs[i] = upkeepObservation.UpkeepIdentifiers[:observationUpkeepsLimit]
+			ids := upkeepObservation.UpkeepIdentifiers[:]
+			if len(ids) > observationUpkeepsLimit {
+				ids = ids[:observationUpkeepsLimit]
+			}
+
+			upkeepIDs[i] = ids
 		}
 	}
 


### PR DESCRIPTION
When observation length limit is changed, the current comparison to zero will cause a panic. This change compares the length to the limit instead.