### PR TITLE
Log trigger observer

### DIFF
--- a/internal/util/q.go
+++ b/internal/util/q.go
@@ -1,0 +1,60 @@
+package util
+
+import (
+	"sync"
+)
+
+// Queue saves generic data in buckets, each bucket has a key and it holds a list of items.
+type Queue[V any] struct {
+	data []V
+	mu   *sync.RWMutex
+}
+
+// NewQueue creates a new queue with the given generic types
+func NewQueue[V any]() *Queue[V] {
+	return &Queue[V]{
+		data: make([]V, 0),
+		mu:   &sync.RWMutex{},
+	}
+}
+
+// Push adds items to the q, it is possible to add values of multiple buckets
+func (q *Queue[V]) Push(vals ...V) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	q.data = append(q.data, vals...)
+}
+
+// Pop returns the corresponding items and removed them from the q
+// TBD: amount of items to pop vs. filter function
+func (q *Queue[V]) Pop(n int) []V {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	newlist, removed := pop(q.data, n)
+	q.data = newlist
+
+	return removed
+}
+
+// Size returs the size of the list for a specific key
+func (q *Queue[V]) Size() int {
+	q.mu.RLock()
+	defer q.mu.RUnlock()
+
+	return len(q.data)
+}
+
+// Pop returns the corresponding items and removed them from the q
+func pop[V any](list []V, n int) ([]V, []V) {
+	size := len(list)
+	// ensure we don't overflow by auto-correct n
+	if n > size || n <= 0 {
+		n = size
+	}
+	removed := list[:n]
+	list = list[n:]
+
+	return list, removed
+}

--- a/internal/util/q.go
+++ b/internal/util/q.go
@@ -20,6 +20,9 @@ func NewQueue[V any]() *Queue[V] {
 
 // Push adds items to the q, it is possible to add values of multiple buckets
 func (q *Queue[V]) Push(vals ...V) {
+	if len(vals) == 0 {
+		return
+	}
 	q.mu.Lock()
 	defer q.mu.Unlock()
 

--- a/internal/util/q.go
+++ b/internal/util/q.go
@@ -38,6 +38,25 @@ func (q *Queue[V]) Pop(n int) []V {
 	return removed
 }
 
+func (q *Queue[V]) PopF(filter func(V) bool) []V {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	removed := make([]V, 0)
+	updated := make([]V, 0)
+	for i, v := range q.data {
+		if filter(v) {
+			removed = append(removed, q.data[i])
+		} else {
+			updated = append(updated, v)
+		}
+	}
+
+	q.data = updated
+
+	return removed
+}
+
 // Size returs the size of the list for a specific key
 func (q *Queue[V]) Size() int {
 	q.mu.RLock()

--- a/internal/util/q_test.go
+++ b/internal/util/q_test.go
@@ -1,0 +1,70 @@
+package util
+
+import (
+	"context"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestQueue(t *testing.T) {
+	t.Run("Push", func(t *testing.T) {
+		q := NewQueue[string]()
+		q.Push("a", "b", "c")
+		require.Equal(t, 3, q.Size())
+	})
+	t.Run("Pop", func(t *testing.T) {
+		q := NewQueue[string]()
+		added := []string{"a", "b", "c"}
+		q.Push(added...)
+		require.Equal(t, 3, q.Size())
+		require.Len(t, q.Pop(1), 1, "should pop 1 item")
+		require.Len(t, q.Pop(-1), len(added)-1, "should pop remaining items")
+		require.Equal(t, 0, q.Size())
+		require.Len(t, q.Pop(1), 0, "empty queue shouldn't have items")
+		require.Len(t, q.Pop(0), 0, "empty queue shouldn't have items")
+	})
+}
+
+func TestQueue_Concurrency(t *testing.T) {
+	pctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	q := NewQueue[string]()
+	in := make(chan []string)
+
+	go func() {
+		ctx, cancel := context.WithCancel(pctx)
+		defer cancel()
+
+		for {
+			select {
+			case d := <-in:
+				q.Push(d...)
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	go func() {
+		in <- []string{"a", "b", "c"}
+	}()
+	go func() {
+		in <- []string{"d", "e", "f"}
+	}()
+
+	acc := []string{}
+	for pctx.Err() == nil {
+		popped := q.Pop(-1)
+		if len(popped) > 0 {
+			acc = append(acc, popped...)
+		}
+		if len(acc) == 6 {
+			break
+		}
+		runtime.Gosched()
+	}
+	require.Equal(t, 6, len(acc))
+}

--- a/internal/util/q_test.go
+++ b/internal/util/q_test.go
@@ -25,6 +25,25 @@ func TestQueue(t *testing.T) {
 		require.Len(t, q.Pop(1), 0, "empty queue shouldn't have items")
 		require.Len(t, q.Pop(0), 0, "empty queue shouldn't have items")
 	})
+
+	t.Run("PopF", func(t *testing.T) {
+		q := NewQueue[string]()
+		added := []string{"a", "b", "c"}
+		q.Push(added...)
+
+		require.Equal(t, 3, q.Size())
+		require.Len(t, q.PopF(func(s string) bool {
+			return s == "a"
+		}), 1, "should pop a single item")
+		require.Equal(t, 2, q.Size())
+		require.Len(t, q.PopF(func(s string) bool {
+			return true
+		}), len(added)-1, "should pop the remaining items")
+		require.Equal(t, 0, q.Size())
+		require.Len(t, q.PopF(func(s string) bool {
+			return true
+		}), 0, "empty queue shouldn't have items")
+	})
 }
 
 func TestQueue_Concurrency(t *testing.T) {

--- a/internal/util/q_test.go
+++ b/internal/util/q_test.go
@@ -14,6 +14,7 @@ func TestQueue(t *testing.T) {
 		q.Push("a", "b", "c")
 		require.Equal(t, 3, q.Size())
 	})
+
 	t.Run("Pop", func(t *testing.T) {
 		q := NewQueue[string]()
 		added := []string{"a", "b", "c"}
@@ -51,27 +52,12 @@ func TestQueue_Concurrency(t *testing.T) {
 	defer cancel()
 
 	q := NewQueue[string]()
-	in := make(chan []string)
 
 	go func() {
-		ctx, cancel := context.WithCancel(pctx)
-		defer cancel()
-
-		for {
-			select {
-			case d := <-in:
-				q.Push(d...)
-			case <-ctx.Done():
-				return
-			}
-		}
-	}()
-
-	go func() {
-		in <- []string{"a", "b", "c"}
+		q.Push("a", "b", "c")
 	}()
 	go func() {
-		in <- []string{"d", "e", "f"}
+		q.Push("d", "e", "f")
 	}()
 
 	acc := []string{}

--- a/pkg/observer/execution/executer.go
+++ b/pkg/observer/execution/executer.go
@@ -1,0 +1,180 @@
+package execution
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/smartcontractkit/ocr2keepers/internal/util"
+	"github.com/smartcontractkit/ocr2keepers/pkg/types"
+	pkgutil "github.com/smartcontractkit/ocr2keepers/pkg/util"
+)
+
+var ErrTooManyErrors = fmt.Errorf("too many errors in parallel worker process")
+
+type executer struct {
+	logger *log.Logger
+
+	registry types.Registry
+
+	workers      *pkgutil.WorkerGroup[types.UpkeepResults]
+	cache        *pkgutil.Cache[types.UpkeepResult]
+	cacheCleaner *pkgutil.IntervalCacheCleaner[types.UpkeepResult]
+
+	rpcBatchLimit int
+}
+
+var _ types.Executer = &executer{}
+
+func NewExecuter(
+	logger *log.Logger,
+	registry types.Registry,
+	cacheExpire time.Duration,
+	cacheClean time.Duration,
+	workers int, // maximum number of workers in worker group
+	workerQueueSize int, // size of worker queue; set to approximately the number of items expected in workload
+	rpcBatchLimit int,
+) *executer {
+	return &executer{
+		logger:   logger,
+		registry: registry,
+
+		workers:      pkgutil.NewWorkerGroup[types.UpkeepResults](workers, workerQueueSize),
+		cache:        pkgutil.NewCache[types.UpkeepResult](cacheExpire),
+		cacheCleaner: pkgutil.NewIntervalCacheCleaner[types.UpkeepResult](cacheClean),
+
+		rpcBatchLimit: rpcBatchLimit,
+	}
+}
+
+func (ex *executer) Run(ctx context.Context, keys []types.UpkeepKey, checkData [][]byte) (types.UpkeepResults, error) {
+	if len(keys) == 0 {
+		return nil, nil
+	}
+
+	var wResults util.Results
+
+	pkgutil.RunJobs(
+		ctx,
+		ex.workers,
+		util.Unflatten(keys, ex.rpcBatchLimit),
+		ex.wrapWorkerFunc(),
+		ex.wrapAggregate(&wResults),
+	)
+
+	if wResults.Total() == 0 {
+		ex.logger.Printf("no network calls were made for this sampling set")
+	} else {
+		ex.logger.Printf("worker call success rate: %.2f; failure rate: %.2f; total calls %d", wResults.SuccessRate(), wResults.FailureRate(), wResults.Total())
+	}
+
+	// multiple network calls can result in an error while some can be successful
+	// in the case that all workers encounter an error, bubble this up as a hard
+	// failure of the process.
+	if wResults.Total() > 0 && wResults.Total() == wResults.Failures && wResults.Err != nil {
+		return nil, fmt.Errorf("%w: last error encounter by worker was '%s'", ErrTooManyErrors, wResults.Err)
+	}
+
+	results := make([]types.UpkeepResult, 0)
+	for _, key := range keys {
+		res, ok := ex.cache.Get(key.String())
+		if !ok {
+			// TODO: handle?
+			continue
+		}
+		results = append(results, res)
+	}
+
+	return results, nil
+}
+
+func (ex *executer) eligible(result types.UpkeepResult) bool {
+	// TODO
+	// return ex.eligibilityProvider.Eligible(result)
+	return true
+}
+
+func (ex *executer) wrapWorkerFunc() func(context.Context, []types.UpkeepKey) (types.UpkeepResults, error) {
+	return func(ctx context.Context, keys []types.UpkeepKey) (types.UpkeepResults, error) {
+		start := time.Now()
+
+		// perform check and update cache with result
+		checkResults, err := ex.checkUpkeeps(ctx, keys...)
+		if err != nil {
+			err = fmt.Errorf("%w: failed to check upkeep keys: %s", err, keys)
+		} else {
+			ex.logger.Printf("check %d upkeeps took %dms to perform", len(keys), time.Since(start)/time.Millisecond)
+
+			for _, result := range checkResults {
+				if ex.eligible(result) {
+					ex.logger.Printf("upkeep ready to perform for key %s", result.Key)
+				} else {
+					ex.logger.Printf("upkeep '%s' is not eligible with failure reason: %d", result.Key, result.FailureReason)
+				}
+			}
+		}
+
+		return checkResults, err
+	}
+}
+
+func (ex *executer) wrapAggregate(r *util.Results) func(types.UpkeepResults, error) {
+	return func(result types.UpkeepResults, err error) {
+		if err == nil {
+			r.Successes++
+			// TODO: check eligibility?
+			// for _, res := range result {
+			// 	ex.cache.Set(res.Key.String(), res, pkgutil.DefaultCacheExpiration)
+			// 	// if ex.eligible(res) {
+			// 	// 	_, id, err := ex.upkeepProvider.SplitUpkeepKey(res.Key)
+			// 	// 	if err != nil {
+			// 	// 		continue
+			// 	// 	}
+			// 	// 	// ex.stager.prepareIdentifier(id) // TODO: check
+			// 	// }
+			// }
+		} else {
+			r.Err = err
+			ex.logger.Printf("error received from worker result: %s", err)
+			r.Failures++
+		}
+	}
+}
+
+// checkUpkeeps does an upkeep check for the given keys, it utilizes a cache to avoid redundant calls.
+func (ex *executer) checkUpkeeps(ctx context.Context, keys ...types.UpkeepKey) ([]types.UpkeepResult, error) {
+	var (
+		results           = make([]types.UpkeepResult, len(keys))
+		nonCachedKeysIdxs = make([]int, 0, len(keys))
+		nonCachedKeys     = make([]types.UpkeepKey, 0, len(keys))
+	)
+
+	for i, key := range keys {
+		if result, cached := ex.cache.Get(key.String()); cached {
+			results[i] = result
+		} else {
+			nonCachedKeysIdxs = append(nonCachedKeysIdxs, i)
+			nonCachedKeys = append(nonCachedKeys, key)
+		}
+	}
+
+	// no execution required, all keys are cached
+	if len(nonCachedKeys) == 0 {
+		return results, nil
+	}
+
+	// check upkeep at block number in key
+	// return result including performData
+	checkResults, err := ex.registry.CheckUpkeep(ctx, nonCachedKeys...)
+	if err != nil {
+		return nil, fmt.Errorf("%w: service failed to check upkeep from registry", err)
+	}
+
+	for i, u := range checkResults {
+		ex.cache.Set(keys[nonCachedKeysIdxs[i]].String(), u, pkgutil.DefaultCacheExpiration)
+		results[nonCachedKeysIdxs[i]] = u
+	}
+
+	return results, nil
+}

--- a/pkg/observer/execution/executer.go
+++ b/pkg/observer/execution/executer.go
@@ -48,6 +48,7 @@ func NewExecuter(
 	}
 }
 
+// Run executes checkUpkeep for the given keys and their checkData that is used in log upkeeps scenario
 func (ex *executer) Run(ctx context.Context, keys []types.UpkeepKey, checkData [][]byte) (types.UpkeepResults, error) {
 	if len(keys) == 0 {
 		return nil, nil

--- a/pkg/observer/logs/observer.go
+++ b/pkg/observer/logs/observer.go
@@ -1,0 +1,68 @@
+package logs
+
+import (
+	"context"
+	"log"
+	"time"
+
+	gethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/smartcontractkit/ocr2keepers/pkg/observer"
+	"github.com/smartcontractkit/ocr2keepers/pkg/types"
+)
+
+// LogProvider is used by the observer to get upkeep related log events
+type LogProvider interface {
+	// TODO: TBD range, results type
+	GetLogsData(upkeepIDs ...types.UpkeepIdentifier) ([]gethtypes.Log, error)
+}
+
+type logTriggerObserver struct {
+	logger *log.Logger
+
+	executer    types.Executer
+	logProvider LogProvider
+
+	q *LogUpkeepsQueue
+}
+
+var _ observer.ObserverV2[time.Time] = &logTriggerObserver{}
+
+func (o *logTriggerObserver) Process(ctx context.Context, t time.Time) {
+	upkeeps, checkData, err := o.getExecutableUpkeeps(ctx)
+	if err != nil {
+		o.logger.Printf("failed to get executable upkeeps: %s", err.Error())
+		return
+	}
+	if len(upkeeps) == 0 {
+		o.logger.Println("could not find executable upkeeps")
+		return
+	}
+	results, err := o.executer.Run(ctx, upkeeps, checkData)
+	if err != nil {
+		o.logger.Printf("failed to execute upkeeps: %s", err.Error())
+		return
+	}
+	o.q.Push(results...)
+}
+
+// getExecutableUpkeeps returns a list of upkeeps to execute at the moment and the corresponding check data
+func (o *logTriggerObserver) getExecutableUpkeeps(ctx context.Context) ([]types.UpkeepKey, [][]byte, error) {
+	var upkeeps []types.UpkeepIdentifier // TODO: populate upkeeps
+	logs, err := o.logProvider.GetLogsData(upkeeps...)
+	if err != nil {
+		return nil, nil, err
+	}
+	var upkeepKeys []types.UpkeepKey
+	var checkData [][]byte
+	// TODO: complete
+	for _, log := range logs {
+		checkData = append(checkData, log.Data)
+		// upkeepKeys = append(upkeepKeys, upkeepKey)
+	}
+	return upkeepKeys, checkData, nil
+}
+
+// Propose returns the results that exist in the queue at the moment
+func (o *logTriggerObserver) Propose(ctx context.Context) ([]types.UpkeepResult, error) {
+	return o.q.Pop(-1), nil
+}

--- a/pkg/observer/logs/observer.go
+++ b/pkg/observer/logs/observer.go
@@ -27,6 +27,19 @@ type logTriggerObserver struct {
 
 var _ observer.ObserverV2[time.Time] = &logTriggerObserver{}
 
+func NewLogTriggerObserver(
+	logger *log.Logger,
+	executer types.Executer,
+	logProvider LogProvider,
+) *logTriggerObserver {
+	return &logTriggerObserver{
+		logger:      logger,
+		executer:    executer,
+		logProvider: logProvider,
+		q:           NewUpkeepsQueue(),
+	}
+}
+
 func (o *logTriggerObserver) Process(ctx context.Context, t time.Time) {
 	upkeeps, checkData, err := o.getExecutableUpkeeps(ctx)
 	if err != nil {

--- a/pkg/observer/logs/q.go
+++ b/pkg/observer/logs/q.go
@@ -30,15 +30,11 @@ func (uq *LogUpkeepsQueue) Pop(n int) []types.UpkeepResult {
 	return removed
 }
 
-// Clean removes and returns the messages that were already visited in the past
-func (uq *LogUpkeepsQueue) PopVisited(n int) []types.UpkeepResult {
-	return uq.visited.Pop(n)
-}
-
 func (uq *LogUpkeepsQueue) Size() int {
 	return uq.base.Size()
 }
 
-func (uq *LogUpkeepsQueue) SizeVisited() int {
-	return uq.visited.Size()
+// Visited returns the results that were already visited in the past
+func (uq *LogUpkeepsQueue) Visited() *util.Queue[types.UpkeepResult] {
+	return uq.visited
 }

--- a/pkg/observer/logs/q.go
+++ b/pkg/observer/logs/q.go
@@ -30,11 +30,20 @@ func (uq *LogUpkeepsQueue) Pop(n int) []types.UpkeepResult {
 	return removed
 }
 
+// Size returns the amount of items in the base q
 func (uq *LogUpkeepsQueue) Size() int {
 	return uq.base.Size()
 }
 
 // Visited returns the results that were already visited in the past
-func (uq *LogUpkeepsQueue) Visited() *util.Queue[types.UpkeepResult] {
-	return uq.visited
+func (uq *LogUpkeepsQueue) Visited() int {
+	return uq.visited.Size()
+}
+
+// Clean invokes a cleanup of visited upkeeps, it will re-push results that were not cleaned (TBD)
+func (uq *LogUpkeepsQueue) Clean(cleaner func(types.UpkeepResult) bool) {
+	_ = uq.visited.PopF(cleaner)
+
+	leftovers := uq.visited.Pop(-1)
+	uq.base.Push(leftovers...)
 }

--- a/pkg/observer/logs/q.go
+++ b/pkg/observer/logs/q.go
@@ -1,0 +1,44 @@
+package logs
+
+import (
+	"github.com/smartcontractkit/ocr2keepers/internal/util"
+	"github.com/smartcontractkit/ocr2keepers/pkg/types"
+)
+
+// LogUpkeepsQueue holds internal queues to manage currently executed upkeeps
+type LogUpkeepsQueue struct {
+	base    *util.Queue[types.UpkeepResult]
+	visited *util.Queue[types.UpkeepResult]
+}
+
+func NewUpkeepsQueue() *LogUpkeepsQueue {
+	return &LogUpkeepsQueue{
+		base:    util.NewQueue[types.UpkeepResult](),
+		visited: util.NewQueue[types.UpkeepResult](),
+	}
+}
+
+// Push adds items to the q, it is possible to add values of multiple buckets
+func (uq *LogUpkeepsQueue) Push(vals ...types.UpkeepResult) {
+	uq.base.Push(vals...)
+}
+
+// Pop returns the corresponding items and removed them from the q
+func (uq *LogUpkeepsQueue) Pop(n int) []types.UpkeepResult {
+	removed := uq.base.Pop(n)
+	uq.visited.Push(removed...)
+	return removed
+}
+
+// Clean removes and returns the messages that were already visited in the past
+func (uq *LogUpkeepsQueue) PopVisited(n int) []types.UpkeepResult {
+	return uq.visited.Pop(n)
+}
+
+func (uq *LogUpkeepsQueue) Size() int {
+	return uq.base.Size()
+}
+
+func (uq *LogUpkeepsQueue) SizeVisited() int {
+	return uq.visited.Size()
+}

--- a/pkg/observer/logs/q_test.go
+++ b/pkg/observer/logs/q_test.go
@@ -12,26 +12,25 @@ import (
 
 func TestUpkeepsQueue_e2e(t *testing.T) {
 	q := NewUpkeepsQueue()
-	visited := q.Visited()
 	block := big.NewInt(1)
-	q.Push(randUpkeepResult(block), randUpkeepResult(block))
+	u1, u2 := randUpkeepResult(block), randUpkeepResult(block)
+	q.Push(u1, u2)
 	require.Equal(t, 2, q.Size())
-	require.Equal(t, 0, visited.Size())
-
-	block = block.Add(block, big.NewInt(1))
-	q.Push(randUpkeepResult(block), randUpkeepResult(block))
-	require.Equal(t, 4, q.Size())
-	require.Equal(t, 0, visited.Size())
+	require.Equal(t, 0, q.Visited())
 
 	results := q.Pop(2)
 	require.Len(t, results, 2)
-	require.Equal(t, 2, q.Size())
-	require.Equal(t, 2, visited.Size())
+	require.Equal(t, 0, q.Size())
+	require.Equal(t, 2, q.Visited())
 
-	results = visited.Pop(2)
-	require.Len(t, results, 2)
-	require.Equal(t, 2, q.Size())
-	require.Equal(t, 0, visited.Size())
+	// cleaning one upkeep, the other one goes back to q
+	keysMap := make(map[string]bool)
+	keysMap[u1.Key.String()] = true
+	q.Clean(func(ur types.UpkeepResult) bool {
+		return keysMap[ur.Key.String()]
+	})
+	require.Equal(t, 1, q.Size())
+	require.Equal(t, 0, q.Visited())
 }
 
 func randUpkeepResult(block *big.Int) types.UpkeepResult {

--- a/pkg/observer/logs/q_test.go
+++ b/pkg/observer/logs/q_test.go
@@ -1,0 +1,41 @@
+package logs
+
+import (
+	"math/big"
+	"math/rand"
+	"testing"
+
+	"github.com/smartcontractkit/ocr2keepers/pkg/chain"
+	"github.com/smartcontractkit/ocr2keepers/pkg/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpkeepsQueue_e2e(t *testing.T) {
+	q := NewUpkeepsQueue()
+
+	block := big.NewInt(1)
+	q.Push(randUpkeepResult(block), randUpkeepResult(block))
+	require.Equal(t, 2, q.Size())
+	require.Equal(t, 0, q.SizeVisited())
+
+	block = block.Add(block, big.NewInt(1))
+	q.Push(randUpkeepResult(block), randUpkeepResult(block))
+	require.Equal(t, 4, q.Size())
+	require.Equal(t, 0, q.SizeVisited())
+
+	results := q.Pop(2)
+	require.Len(t, results, 2)
+	require.Equal(t, 2, q.Size())
+	require.Equal(t, 2, q.SizeVisited())
+
+	results = q.PopVisited(2)
+	require.Len(t, results, 2)
+	require.Equal(t, 2, q.Size())
+	require.Equal(t, 0, q.SizeVisited())
+}
+
+func randUpkeepResult(block *big.Int) types.UpkeepResult {
+	return types.UpkeepResult{
+		Key: chain.NewUpkeepKey(block, big.NewInt(rand.Int63n(1e9))),
+	}
+}

--- a/pkg/observer/logs/q_test.go
+++ b/pkg/observer/logs/q_test.go
@@ -12,26 +12,26 @@ import (
 
 func TestUpkeepsQueue_e2e(t *testing.T) {
 	q := NewUpkeepsQueue()
-
+	visited := q.Visited()
 	block := big.NewInt(1)
 	q.Push(randUpkeepResult(block), randUpkeepResult(block))
 	require.Equal(t, 2, q.Size())
-	require.Equal(t, 0, q.SizeVisited())
+	require.Equal(t, 0, visited.Size())
 
 	block = block.Add(block, big.NewInt(1))
 	q.Push(randUpkeepResult(block), randUpkeepResult(block))
 	require.Equal(t, 4, q.Size())
-	require.Equal(t, 0, q.SizeVisited())
+	require.Equal(t, 0, visited.Size())
 
 	results := q.Pop(2)
 	require.Len(t, results, 2)
 	require.Equal(t, 2, q.Size())
-	require.Equal(t, 2, q.SizeVisited())
+	require.Equal(t, 2, visited.Size())
 
-	results = q.PopVisited(2)
+	results = visited.Pop(2)
 	require.Len(t, results, 2)
 	require.Equal(t, 2, q.Size())
-	require.Equal(t, 0, q.SizeVisited())
+	require.Equal(t, 0, visited.Size())
 }
 
 func randUpkeepResult(block *big.Int) types.UpkeepResult {

--- a/pkg/observer/observer.go
+++ b/pkg/observer/observer.go
@@ -29,9 +29,9 @@ type ObserverV2[Tick any] interface {
 	// Verify(ctx context.Context, keys ...UpkeepKey) (UpkeepResults, error)
 }
 
-// RegsiterObserver manages a pair of observer/ticker, upon each tick the observer is called
+// RegisterObservers manages a pair of observer/ticker, upon each tick the observer is called
 // with the data received from the channel.
-func RegsiterObservers[T any](
+func RegisterObservers[T any](
 	pctx context.Context,
 	cn <-chan T,
 	observers ...ObserverV2[T],

--- a/pkg/observer/observer.go
+++ b/pkg/observer/observer.go
@@ -15,3 +15,69 @@ type Observer interface {
 	SetSamplingRatio(ratio ratio.SampleRatio)
 	SetMercuryLookup(mercuryLookup bool)
 }
+
+// Observer orchestrates the processing of upkeeps and the exposure of triggered upkeeps for the OCR plugin.
+// Tick is a generic input the service gets from the corresponding ticker (block/time ticker)
+// that invokes the observer.
+type ObserverV2[Tick any] interface {
+	// Process execute upkeeps, triggered by a generic ticker
+	Process(ctx context.Context, t Tick)
+	// Propose returns queued upkeep results, called from the OCR plugin upon observation
+	Propose(ctx context.Context) ([]types.UpkeepResult, error)
+	// Verify executes the given upkeeps
+	// decision: not needed for pure reporting
+	// Verify(ctx context.Context, keys ...UpkeepKey) (UpkeepResults, error)
+}
+
+// RegsiterObserver manages a pair of observer/ticker, upon each tick the observer is called
+// with the data received from the channel.
+func RegsiterObservers[T any](
+	pctx context.Context,
+	cn <-chan T,
+	observers ...ObserverV2[T],
+) {
+	ctx, cancel := context.WithCancel(pctx)
+	defer cancel()
+
+	for {
+		select {
+		case t := <-cn:
+			for _, o := range observers {
+				// TODO: concurrency control
+				go o.Process(ctx, t)
+			}
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+// ```mermaid
+// sequenceDiagram
+//     participant Ticker
+//     participant Observer
+//     %% TODO: participant Coordinator
+//     participant Executer
+//     participant Registry
+//     participant MercuryLookup
+//     participant Encoder
+
+//     par Upkeeps processing
+//         Ticker->>Observer: Process(ctx, t)
+//         Observer->>Observer: getExecutableUpkeeps()
+//         Note over Observer,Observer: NOTE: getExecutableUpkeeps differs between trigger types
+//         Observer->>Encoder: EncodeUpkeeps([]upkeep)
+//         Encoder-->>Observer: ([]UpkeepKey, []checkData)
+//         Observer->>Executer: Execute(ctx, []UpkeepIdentifier, []checkData)
+//         loop for each upkeep execute concurrently
+//             Executer->>Executer: cache lookup
+//             Executer->>Registry: CheckUpkeep([]UpkeepID, [][]checkData)
+//             Registry-->>Executer: [[]UpkeepResult]
+//             Note over Executer,MercuryLookup: TODO: mercury lookup
+//             Executer->>Executer: cache update
+//         end
+//         Executer-->>Observer: []UpkeepResult
+//         Observer->>Observer: Add results to queue
+//         Note over Observer,Observer: NOTE: Each adapter maintains a queue of upkeeps results
+// end
+// ```

--- a/pkg/observer/observer_test.go
+++ b/pkg/observer/observer_test.go
@@ -23,7 +23,7 @@ func TestRegisterObservers(t *testing.T) {
 		require.Greater(t, o2.getCount(), int32(0))
 	})
 
-	RegsiterObservers[time.Time](ctx, tk.C, o1, o2)
+	RegisterObservers[time.Time](ctx, tk.C, o1, o2)
 }
 
 type mockObserver struct {

--- a/pkg/observer/observer_test.go
+++ b/pkg/observer/observer_test.go
@@ -1,0 +1,43 @@
+package observer
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/smartcontractkit/ocr2keepers/pkg/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRegisterObservers(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	tick := time.Millisecond * 2
+	o1, o2 := new(mockObserver), new(mockObserver)
+	tk := time.NewTicker(tick)
+
+	time.AfterFunc(time.Duration(tick*2), func() {
+		cancel()
+		require.Greater(t, o1.getCount(), int32(0))
+		require.Greater(t, o2.getCount(), int32(0))
+	})
+
+	RegsiterObservers[time.Time](ctx, tk.C, o1, o2)
+}
+
+type mockObserver struct {
+	processCount int32
+}
+
+func (o *mockObserver) Process(ctx context.Context, t time.Time) {
+	atomic.AddInt32(&o.processCount, 1)
+}
+
+func (o *mockObserver) Propose(ctx context.Context) ([]types.UpkeepResult, error) {
+	return nil, nil
+}
+
+func (o *mockObserver) getCount() int32 {
+	return atomic.LoadInt32(&o.processCount)
+}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -50,7 +50,7 @@ type Registry interface {
 type Executer interface {
 	// Run executes the pipeline for the given upkeeps and collects the results.
 	// checkData is changed based on trigger.
-	Run(ctx context.Context, upkeepKeys []UpkeepKey, checkData [][]byte) (UpkeepResults, error)
+	Run(ctx context.Context, upkeepKeys []UpkeepKey, checkData [][]byte) ([]UpkeepResult, error)
 }
 
 // ReportEncoder represents the report encoder behaviour

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -44,6 +44,15 @@ type Registry interface {
 	CheckUpkeep(context.Context, bool, ...UpkeepKey) (UpkeepResults, error)
 }
 
+// Executer provides a runtime layer for parallelized execution of upkeeps,
+// with a cache for executed/pending upkeeps.
+// It acts as a mediator between observers and registry contract / mercury lookup.
+type Executer interface {
+	// Run executes the pipeline for the given upkeeps and collects the results.
+	// checkData is changed based on trigger.
+	Run(ctx context.Context, upkeepKeys []UpkeepKey, checkData [][]byte) (UpkeepResults, error)
+}
+
 // ReportEncoder represents the report encoder behaviour
 //
 //go:generate mockery --name ReportEncoder --srcpkg "github.com/smartcontractkit/ocr2keepers/pkg/types"   --case underscore --filename report_encoder.generated.go


### PR DESCRIPTION
**NOTE** WIP

## Motivation

The introduction of new trigger type (log trigger) require some changes in our current design so it would fit side by side with other, existing (or future) trigger types.

`Observer` is a trigger agnostic interface for upkeeps, it orchestrates the processing of upkeeps and the exposure of triggered upkeeps for the OCR plugin.

## Description

This PR introduce the new `Observer` interface that was agreed in design phase, and the corresponding implementation of `LogTriggerObserver` that is responsible for log trigger upkeeps.

**NOTE** polling observer for conditional upkeeps will be aligned separately in the future

The following components were added:
- `LogTriggerObserver`
- `Executer` that is used for upkeeps execution by all observers
- Queue/pool to serve the results async to the OCR plugin.

