### PR TITLE
Add a result store

### DIFF
--- a/pkg/stores.go
+++ b/pkg/stores.go
@@ -1,0 +1,37 @@
+package ocr2keepers
+
+import "fmt"
+
+type ResultStore[T any] interface {
+	Add(T)
+	Remove(T)
+	View() ([]T, error)
+}
+
+type resultStore[T any] struct {
+	data map[string]T
+}
+
+func NewResultStore[T any]() *resultStore[T] {
+	return &resultStore[T]{
+		data: make(map[string]T),
+	}
+}
+
+func (s *resultStore[T]) Add(result T) {
+	key := fmt.Sprintf("%v", result)
+	s.data[key] = result
+}
+
+func (s *resultStore[T]) Remove(result T) {
+	key := fmt.Sprintf("%v", result)
+	delete(s.data, key)
+}
+
+func (s *resultStore[T]) View() ([]T, error) {
+	var result []T
+	for _, r := range s.data {
+		result = append(result, r)
+	}
+	return result, nil
+}

--- a/pkg/stores.go
+++ b/pkg/stores.go
@@ -18,14 +18,18 @@ func NewResultStore[T any]() *resultStore[T] {
 	}
 }
 
-func (s *resultStore[T]) Add(result T) {
-	key := fmt.Sprintf("%v", result)
-	s.data[key] = result
+func (s *resultStore[T]) Add(results ...T) {
+	for _, result := range results {
+		key := fmt.Sprintf("%v", result)
+		s.data[key] = result
+	}
 }
 
-func (s *resultStore[T]) Remove(result T) {
-	key := fmt.Sprintf("%v", result)
-	delete(s.data, key)
+func (s *resultStore[T]) Remove(results ...T) {
+	for _, result := range results {
+		key := fmt.Sprintf("%v", result)
+		delete(s.data, key)
+	}
 }
 
 func (s *resultStore[T]) View() ([]T, error) {

--- a/pkg/stores_test.go
+++ b/pkg/stores_test.go
@@ -14,17 +14,17 @@ type checkResult struct {
 func TestNewResultStore(t *testing.T) {
 	t.Run("add", func(t *testing.T) {
 		store := NewResultStore[checkResult]()
-		result := checkResult{
+		result1 := checkResult{
 			Retryable: false,
 			Data:      "some data",
 		}
 
-		store.Add(result)
+		store.Add(result1)
 		results, err := store.View()
 		assert.Nil(t, err)
 		assert.Len(t, results, 1)
 
-		store.Add(result)
+		store.Add(result1)
 		results, err = store.View()
 		assert.Nil(t, err)
 		assert.Len(t, results, 1)
@@ -47,6 +47,11 @@ func TestNewResultStore(t *testing.T) {
 		assert.Nil(t, err)
 		assert.Len(t, results, 2)
 
+		store.Add(result1, result2, result3)
+		results, err = store.View()
+		assert.Nil(t, err)
+		assert.Len(t, results, 2)
+
 		t.Run("remove", func(t *testing.T) {
 			store.Remove(result2)
 			results, err = store.View()
@@ -54,6 +59,11 @@ func TestNewResultStore(t *testing.T) {
 			assert.Len(t, results, 1)
 
 			store.Remove(result2)
+			results, err = store.View()
+			assert.Nil(t, err)
+			assert.Len(t, results, 1)
+
+			store.Remove(result2, result2)
 			results, err = store.View()
 			assert.Nil(t, err)
 			assert.Len(t, results, 1)

--- a/pkg/stores_test.go
+++ b/pkg/stores_test.go
@@ -1,0 +1,68 @@
+package ocr2keepers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type checkResult struct {
+	Retryable bool
+	Data      string
+}
+
+func TestNewResultStore(t *testing.T) {
+	t.Run("add", func(t *testing.T) {
+		store := NewResultStore[checkResult]()
+		result := checkResult{
+			Retryable: false,
+			Data:      "some data",
+		}
+
+		store.Add(result)
+		results, err := store.View()
+		assert.Nil(t, err)
+		assert.Len(t, results, 1)
+
+		store.Add(result)
+		results, err = store.View()
+		assert.Nil(t, err)
+		assert.Len(t, results, 1)
+
+		result2 := checkResult{
+			Retryable: false,
+			Data:      "some data",
+		}
+		store.Add(result2)
+		results, err = store.View()
+		assert.Nil(t, err)
+		assert.Len(t, results, 1)
+
+		result3 := checkResult{
+			Retryable: false,
+			Data:      "some other data",
+		}
+		store.Add(result3)
+		results, err = store.View()
+		assert.Nil(t, err)
+		assert.Len(t, results, 2)
+
+		t.Run("remove", func(t *testing.T) {
+			store.Remove(result2)
+			results, err = store.View()
+			assert.Nil(t, err)
+			assert.Len(t, results, 1)
+
+			store.Remove(result2)
+			results, err = store.View()
+			assert.Nil(t, err)
+			assert.Len(t, results, 1)
+
+			store.Remove(result3)
+			results, err = store.View()
+			assert.Nil(t, err)
+			assert.Len(t, results, 0)
+		})
+	})
+
+}


### PR DESCRIPTION
In this PR, I'm adding a result store that provides functionality to add, remove, and view all items in the store. Under the hood, the store uses a map of strings to generic type.