### PR TITLE
Add a basic time ticker

### DIFF
--- a/pkg/basetypes.go
+++ b/pkg/basetypes.go
@@ -40,3 +40,5 @@ type UpkeepPayload interface{}
 type CheckResult struct {
 	Eligible bool
 }
+
+type UpkeepPayload interface{}

--- a/pkg/basetypes.go
+++ b/pkg/basetypes.go
@@ -40,5 +40,3 @@ type UpkeepPayload interface{}
 type CheckResult struct {
 	Eligible bool
 }
-
-type UpkeepPayload interface{}

--- a/pkg/tickers/time.go
+++ b/pkg/tickers/time.go
@@ -54,23 +54,20 @@ func NewTimeTicker(interval time.Duration, observer observer, getterFn getUpkeep
 }
 
 func (t *timeTicker) Start() {
-	for {
-		select {
-		case tm := <-t.ticker.C:
-			func() {
-				ctx, cancelFn := context.WithTimeout(t.ctx, t.interval)
-				defer cancelFn()
+	for tm := range t.ticker.C {
+		func() {
+			ctx, cancelFn := context.WithTimeout(t.ctx, t.interval)
+			defer cancelFn()
 
-				tick, err := t.getterFn(ctx, tm)
-				if err != nil {
-					logPrintf("error fetching tick: %s", err.Error())
-				}
+			tick, err := t.getterFn(ctx, tm)
+			if err != nil {
+				logPrintf("error fetching tick: %s", err.Error())
+			}
 
-				if err := t.observer.Process(ctx, tick); err != nil {
-					logPrintf("error processing observer: %s", err.Error())
-				}
-			}()
-		}
+			if err := t.observer.Process(ctx, tick); err != nil {
+				logPrintf("error processing observer: %s", err.Error())
+			}
+		}()
 	}
 }
 

--- a/pkg/tickers/time.go
+++ b/pkg/tickers/time.go
@@ -1,0 +1,84 @@
+package time
+
+import (
+	"context"
+	"log"
+	"time"
+
+	ocr2keepers "github.com/smartcontractkit/ocr2keepers/pkg"
+)
+
+var (
+	logPrintf = log.Printf
+)
+
+type observer interface {
+	Process(context.Context, Tick) error
+}
+
+// Ticker is a process that runs interval ticks.
+type Ticker interface {
+	Start() error
+	Stop() error
+}
+
+// Tick is the container for the individual tick
+type Tick interface {
+	// GetUpkeeps provides upkeeps scoped to the tick
+	GetUpkeeps(ctx context.Context) ([]ocr2keepers.UpkeepPayload, error)
+}
+
+type getUpkeepsFn func(context.Context, time.Time) ([]ocr2keepers.UpkeepPayload, error)
+
+type timeTicker struct {
+	interval time.Duration
+	ticker   *time.Ticker
+	observer observer
+	getterFn getUpkeepsFn
+}
+
+func NewTimeTicker(interval time.Duration, observer observer, getterFn getUpkeepsFn) *timeTicker {
+	t := &timeTicker{
+		interval: interval,
+		ticker:   time.NewTicker(interval),
+		observer: observer,
+		getterFn: getterFn,
+	}
+	go t.Start()
+	return t
+}
+
+func (t *timeTicker) Start() {
+	for {
+		select {
+		case tm := <-t.ticker.C:
+			func() {
+				ctx, cancelFn := context.WithTimeout(context.Background(), t.interval)
+				defer cancelFn()
+
+				if err := t.observer.Process(ctx, tick{
+					getter: t.getterFn,
+					tm:     tm,
+				}); err != nil {
+					logPrintf("error processing observer: %s", err.Error())
+				}
+			}()
+		}
+	}
+}
+
+func (t *timeTicker) Stop() {
+	t.ticker.Stop()
+}
+
+// tick is the specific implementation for a Ticker that runs on a time
+// interval
+type tick struct {
+	tm time.Time
+	// getter gets wrapped by the tick.GetUpkeeps function
+	getter func(context.Context, time.Time) ([]ocr2keepers.UpkeepPayload, error)
+}
+
+func (t tick) GetUpkeeps(ctx context.Context) ([]ocr2keepers.UpkeepPayload, error) {
+	return t.getter(ctx, t.tm)
+}

--- a/pkg/tickers/time_test.go
+++ b/pkg/tickers/time_test.go
@@ -1,0 +1,158 @@
+package time
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+
+	ocr2keepers "github.com/smartcontractkit/ocr2keepers/pkg"
+)
+
+type mockObserver struct {
+	processFn func(context.Context, Tick) error
+}
+
+func (o *mockObserver) Process(ctx context.Context, t Tick) error {
+	return o.processFn(ctx, t)
+}
+
+type mockUpkeepPayload struct {
+	data string
+}
+
+func TestNewTimeTicker(t *testing.T) {
+	t.Run("creates new time ticker with a counting observer", func(t *testing.T) {
+		callCount := 0
+		observr := &mockObserver{
+			processFn: func(ctx context.Context, t Tick) error {
+				callCount++
+				return nil
+			},
+		}
+		upkeepsFn := func(ctx context.Context, t time.Time) ([]ocr2keepers.UpkeepPayload, error) {
+			return nil, nil
+		}
+
+		ticker := NewTimeTicker(100*time.Millisecond, observr, upkeepsFn)
+
+		time.Sleep(450 * time.Millisecond)
+
+		ticker.Stop()
+
+		assert.Equal(t, callCount, 4)
+		time.Sleep(200 * time.Millisecond)
+		assert.Equal(t, callCount, 4)
+	})
+
+	t.Run("creates new time ticker with a processing observer", func(t *testing.T) {
+		callCount := 0
+
+		upkeepPayloads := []ocr2keepers.UpkeepPayload{
+			&mockUpkeepPayload{
+				data: "first mock data payload",
+			},
+			&mockUpkeepPayload{
+				data: "second mock data payload",
+			},
+		}
+
+		observr := &mockObserver{
+			processFn: func(ctx context.Context, tick Tick) error {
+				callCount++
+
+				upkeeps, err := tick.GetUpkeeps(ctx)
+				if err != nil {
+					return err
+				}
+
+				if !reflect.DeepEqual(upkeeps, upkeepPayloads) {
+					t.Fatal("unexpected payloads")
+				}
+				return nil
+			},
+		}
+		upkeepsFn := func(ctx context.Context, t time.Time) ([]ocr2keepers.UpkeepPayload, error) {
+			return upkeepPayloads, nil
+		}
+
+		ticker := NewTimeTicker(100*time.Millisecond, observr, upkeepsFn)
+
+		time.Sleep(450 * time.Millisecond)
+
+		ticker.Stop()
+
+		assert.Equal(t, callCount, 4)
+	})
+
+	t.Run("creates a ticker with an observer that errors on processing", func(t *testing.T) {
+		var msg string
+		oldLogPrintf := logPrintf
+		logPrintf = func(format string, v ...any) {
+			msg = fmt.Sprintf(format, v...)
+		}
+		defer func() {
+			logPrintf = oldLogPrintf
+		}()
+
+		observr := &mockObserver{
+			processFn: func(ctx context.Context, tick Tick) error {
+				return errors.New("boom")
+			},
+		}
+		upkeepsFn := func(ctx context.Context, t time.Time) ([]ocr2keepers.UpkeepPayload, error) {
+			return nil, nil
+		}
+
+		ticker := NewTimeTicker(100*time.Millisecond, observr, upkeepsFn)
+
+		time.Sleep(450 * time.Millisecond)
+
+		ticker.Stop()
+
+		assert.Equal(t, msg, "error processing observer: boom")
+	})
+
+	t.Run("creates a ticker with an observer that exceeds the processing timeout", func(t *testing.T) {
+		successfulCallCount := 0
+
+		var msg string
+		oldLogPrintf := logPrintf
+		logPrintf = func(format string, v ...any) {
+			msg = fmt.Sprintf(format, v...)
+		}
+		defer func() {
+			logPrintf = oldLogPrintf
+		}()
+
+		firstRun := true
+
+		observr := &mockObserver{
+			processFn: func(ctx context.Context, tick Tick) error {
+				if firstRun {
+					firstRun = false
+					<-ctx.Done()
+					return ctx.Err()
+				}
+				successfulCallCount++
+				return nil
+			},
+		}
+		upkeepsFn := func(ctx context.Context, t time.Time) ([]ocr2keepers.UpkeepPayload, error) {
+			return nil, nil
+		}
+
+		ticker := NewTimeTicker(100*time.Millisecond, observr, upkeepsFn)
+
+		time.Sleep(450 * time.Millisecond)
+
+		ticker.Stop()
+
+		assert.Equal(t, msg, "error processing observer: context deadline exceeded")
+		assert.Equal(t, successfulCallCount, 3)
+	})
+}

--- a/pkg/tickers/time_test.go
+++ b/pkg/tickers/time_test.go
@@ -25,6 +25,14 @@ type mockUpkeepPayload struct {
 	data string
 }
 
+type mockTick struct {
+	getUpkeepsFn func(ctx context.Context) ([]ocr2keepers.UpkeepPayload, error)
+}
+
+func (t *mockTick) GetUpkeeps(ctx context.Context) ([]ocr2keepers.UpkeepPayload, error) {
+	return t.getUpkeepsFn(ctx)
+}
+
 func TestNewTimeTicker(t *testing.T) {
 	t.Run("creates new time ticker with a counting observer", func(t *testing.T) {
 		callCount := 0
@@ -34,8 +42,12 @@ func TestNewTimeTicker(t *testing.T) {
 				return nil
 			},
 		}
-		upkeepsFn := func(ctx context.Context, t time.Time) ([]ocr2keepers.UpkeepPayload, error) {
-			return nil, nil
+		upkeepsFn := func(ctx context.Context, t time.Time) (Tick, error) {
+			return &mockTick{
+				getUpkeepsFn: func(ctx context.Context) ([]ocr2keepers.UpkeepPayload, error) {
+					return nil, nil
+				},
+			}, nil
 		}
 
 		ticker := NewTimeTicker(100*time.Millisecond, observr, upkeepsFn)
@@ -76,8 +88,12 @@ func TestNewTimeTicker(t *testing.T) {
 				return nil
 			},
 		}
-		upkeepsFn := func(ctx context.Context, t time.Time) ([]ocr2keepers.UpkeepPayload, error) {
-			return upkeepPayloads, nil
+		upkeepsFn := func(ctx context.Context, t time.Time) (Tick, error) {
+			return &mockTick{
+				getUpkeepsFn: func(ctx context.Context) ([]ocr2keepers.UpkeepPayload, error) {
+					return upkeepPayloads, nil
+				},
+			}, nil
 		}
 
 		ticker := NewTimeTicker(100*time.Millisecond, observr, upkeepsFn)
@@ -104,8 +120,12 @@ func TestNewTimeTicker(t *testing.T) {
 				return errors.New("boom")
 			},
 		}
-		upkeepsFn := func(ctx context.Context, t time.Time) ([]ocr2keepers.UpkeepPayload, error) {
-			return nil, nil
+		upkeepsFn := func(ctx context.Context, t time.Time) (Tick, error) {
+			return &mockTick{
+				getUpkeepsFn: func(ctx context.Context) ([]ocr2keepers.UpkeepPayload, error) {
+					return nil, nil
+				},
+			}, nil
 		}
 
 		ticker := NewTimeTicker(100*time.Millisecond, observr, upkeepsFn)
@@ -142,8 +162,12 @@ func TestNewTimeTicker(t *testing.T) {
 				return nil
 			},
 		}
-		upkeepsFn := func(ctx context.Context, t time.Time) ([]ocr2keepers.UpkeepPayload, error) {
-			return nil, nil
+		upkeepsFn := func(ctx context.Context, t time.Time) (Tick, error) {
+			return &mockTick{
+				getUpkeepsFn: func(ctx context.Context) ([]ocr2keepers.UpkeepPayload, error) {
+					return nil, nil
+				},
+			}, nil
 		}
 
 		ticker := NewTimeTicker(100*time.Millisecond, observr, upkeepsFn)


### PR DESCRIPTION
This PR adds a basic time ticker that runs on a timed interval. On each tick, we call `Process` on the supplied observer. We pass a `Tick` instance to the `Process` function. The `Tick` instance references the time of the tick, and a function for retrieving upkeep payloads. 