### PR TITLE
Update libocr to latest master commit

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/pkg/errors v0.9.1
 	github.com/shopspring/decimal v1.3.1
-	github.com/smartcontractkit/libocr v0.0.0-20230606165449-a80645346b30
+	github.com/smartcontractkit/libocr v0.0.0-20230606215712-82b910bef5c1
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.8.4
 	go.uber.org/multierr v1.11.0

--- a/go.sum
+++ b/go.sum
@@ -72,8 +72,8 @@ github.com/shirou/gopsutil v3.21.11+incompatible h1:+1+c1VGhc88SSonWP6foOcLhvnKl
 github.com/shirou/gopsutil v3.21.11+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
 github.com/shopspring/decimal v1.3.1 h1:2Usl1nmF/WZucqkFZhnfFYxxxu8LG21F6nPQBE5gKV8=
 github.com/shopspring/decimal v1.3.1/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
-github.com/smartcontractkit/libocr v0.0.0-20230606165449-a80645346b30 h1:LzeiWKb1uZvQ54v6uxCLHMLp3fAgI8UX326/26KCe6c=
-github.com/smartcontractkit/libocr v0.0.0-20230606165449-a80645346b30/go.mod h1:2lyRkw/qLQgUWlrWWmq5nj0y90rWeO6Y+v+fCakRgb0=
+github.com/smartcontractkit/libocr v0.0.0-20230606215712-82b910bef5c1 h1:caG9BWjnCxN/HPBA5ltDGadDraZAsjGIct4S8lh8D5c=
+github.com/smartcontractkit/libocr v0.0.0-20230606215712-82b910bef5c1/go.mod h1:2lyRkw/qLQgUWlrWWmq5nj0y90rWeO6Y+v+fCakRgb0=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/status-im/keycard-go v0.2.0 h1:QDLFswOQu1r5jsycloeQh3bVU8n/NatHHaZobtDnDzA=


### PR DESCRIPTION
Small followup from https://github.com/smartcontractkit/ocr2keepers/pull/120, updating to the latest master commit of libocr merged in https://github.com/smartcontractkit/libocr/pull/67

Updates to commit `82b910bef5c1c95cc7a886091ccfc1895bde76f5` which is on the master branch of libocr https://github.com/smartcontractkit/libocr/commits/master

Will be updated in corresponding CL repo https://github.com/smartcontractkit/chainlink/pull/9022