### PR TITLE
Fix memory leak

### DIFF
--- a/pkg/coordinator/coordinator.go
+++ b/pkg/coordinator/coordinator.go
@@ -104,7 +104,7 @@ func NewReportCoordinator(
 		activeKeys:     util.NewCache[bool](time.Hour), // 1 hour allows the cleanup routine to clear stale data
 		idCacheCleaner: util.NewIntervalCacheCleaner[idBlocker](cacheClean),
 		cacheCleaner:   util.NewIntervalCacheCleaner[bool](cacheClean),
-		chStop:         make(chan struct{}),
+		chStop:         make(chan struct{}, 1),
 		encoder:        encoder,
 	}
 

--- a/pkg/observer/polling/observer.go
+++ b/pkg/observer/polling/observer.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"runtime"
 	"sync"
 	"time"
 
@@ -104,12 +103,6 @@ func NewPollingObserver(
 	ob.services = []Service{
 		util.NewRecoverableService(&observer.SimpleService{F: ob.runHeadTasks, C: cancel}, logger),
 	}
-
-	// automatically stop all services if the reference is no longer reachable
-	// this is a safety in the case Stop isn't called explicitly
-	runtime.SetFinalizer(ob, func(srv *PollingObserver) { _ = srv.Close() })
-
-	ob.Start()
 
 	return ob
 }

--- a/pkg/util/worker.go
+++ b/pkg/util/worker.go
@@ -180,6 +180,14 @@ func (wg *WorkerGroup[T]) Results(group int) []WorkItemResult[T] {
 	return resultData
 }
 
+func (wg *WorkerGroup[T]) RemoveGroup(group int) {
+	wg.mu.Lock()
+	defer wg.mu.Unlock()
+
+	delete(wg.resultData, group)
+	delete(wg.resultNotify, group)
+}
+
 func (wg *WorkerGroup[T]) Stop() {
 	wg.once.Do(func() {
 		wg.svcCancel()
@@ -333,6 +341,9 @@ func RunJobs[T, K any](ctx context.Context, wg *WorkerGroup[T], jobs []K, jobFun
 
 	// wait for all results to be read
 	wait.Wait()
+
+	// clean up run group resources
+	wg.RemoveGroup(group)
 
 	// close the results reader process to clean up resources
 	close(end)


### PR DESCRIPTION
The worker group was creating new arrays and channels for each work set and not deleting them when done. Memory was gradually being used up by empty arrays and channels going unused.

The coordinator stop channel had a length of 0 and would block indefinitely until the ability to be read. The length was changed to 1 to ensure the value was sent over the channel.

The observer was automatically starting on creation with a finalizer that stopped the service. Since we are moving to explicit starts and stops, these should no longer be needed.