### PR TITLE
Fix mismatched package names

### DIFF
--- a/pkg/v3/ocr3.go
+++ b/pkg/v3/ocr3.go
@@ -1,4 +1,4 @@
-package v3
+package ocr2keepers
 
 import (
 	"context"
@@ -11,8 +11,6 @@ import (
 type InstructionStore interface{}
 
 type SamplingStore interface{}
-
-type ResultStore interface{}
 
 type ocr3Plugin struct {
 	PrebuildHooks     []func(AutomationOutcome) error

--- a/pkg/v3/ocr3_test.go
+++ b/pkg/v3/ocr3_test.go
@@ -1,4 +1,4 @@
-package v3
+package ocr2keepers
 
 import (
 	"context"


### PR DESCRIPTION
It looks like some changes have been merged with a conflicting package version. This change fixes that. There was also a duplicate `type ResultStore interface{}` declaration, which I removed.