### PR TITLE
Add a block ticker that sends block histories on a channel

### DIFF
--- a/pkg/basetypes.go
+++ b/pkg/basetypes.go
@@ -124,3 +124,5 @@ type ReportedUpkeep struct {
 	// PerformData is the data to perform an upkeep with
 	PerformData []byte
 }
+
+type BlockHistory []BlockKey

--- a/pkg/v3/hooks/build.go
+++ b/pkg/v3/hooks/build.go
@@ -10,7 +10,7 @@ func NewBuildHookAddFromStaging() *BuildHookAddFromStaging {
 
 type BuildHookAddFromStaging struct{}
 
-func (hook *BuildHookAddFromStaging) RunHook(obs *ocr2keepersv3.AutomationObservation, _ ocr2keepersv3.InstructionStore, _ ocr2keepersv3.SamplingStore, rStore ocr2keepersv3.ResultStore) error {
+func (hook *BuildHookAddFromStaging) RunHook(obs *ocr2keepersv3.AutomationObservation, _ ocr2keepersv3.InstructionStore, _ ocr2keepersv3.MetadataStore, rStore ocr2keepersv3.ResultStore) error {
 	results, err := rStore.View()
 	if err != nil {
 		return err

--- a/pkg/v3/plugin/ocr3.go
+++ b/pkg/v3/plugin/ocr3.go
@@ -24,9 +24,9 @@ type Coordinator interface {
 
 type ocr3Plugin[RI any] struct {
 	PrebuildHooks      []func(ocr2keepersv3.AutomationOutcome) error
-	BuildHooks         []func(*ocr2keepersv3.AutomationObservation, ocr2keepersv3.InstructionStore, ocr2keepersv3.SamplingStore, ocr2keepersv3.ResultStore) error
+	BuildHooks         []func(*ocr2keepersv3.AutomationObservation, ocr2keepersv3.InstructionStore, ocr2keepersv3.MetadataStore, ocr2keepersv3.ResultStore) error
 	InstructionSource  ocr2keepersv3.InstructionStore
-	MetadataSource     ocr2keepersv3.SamplingStore
+	MetadataSource     ocr2keepersv3.MetadataStore
 	ResultSource       ocr2keepersv3.ResultStore
 	ReportEncoder      Encoder
 	Coordinator        Coordinator

--- a/pkg/v3/plugin/ocr3_test.go
+++ b/pkg/v3/plugin/ocr3_test.go
@@ -31,7 +31,7 @@ func TestObservation(t *testing.T) {
 	plugin.PrebuildHooks = append(plugin.PrebuildHooks, mockPrebuildHook)
 
 	// Define a mock build hook function for testing build hooks
-	mockBuildHook := func(observation *ocr2keepersv3.AutomationObservation, instructionStore ocr2keepersv3.InstructionStore, samplingStore ocr2keepersv3.SamplingStore, resultStore ocr2keepersv3.ResultStore) error {
+	mockBuildHook := func(observation *ocr2keepersv3.AutomationObservation, instructionStore ocr2keepersv3.InstructionStore, samplingStore ocr2keepersv3.MetadataStore, resultStore ocr2keepersv3.ResultStore) error {
 		assert.Equal(t, 0, len(observation.Instructions))
 		return nil
 	}

--- a/pkg/v3/plugin/plugin.go
+++ b/pkg/v3/plugin/plugin.go
@@ -47,7 +47,7 @@ func newPlugin[RI any](
 			ltFlow.ProcessOutcome,
 			hooks.NewPrebuildHookRemoveFromStaging(rs).RunHook,
 		},
-		BuildHooks: []func(*ocr2keepersv3.AutomationObservation, ocr2keepersv3.InstructionStore, ocr2keepersv3.SamplingStore, ocr2keepersv3.ResultStore) error{
+		BuildHooks: []func(*ocr2keepersv3.AutomationObservation, ocr2keepersv3.InstructionStore, ocr2keepersv3.MetadataStore, ocr2keepersv3.ResultStore) error{
 			hooks.NewBuildHookAddFromStaging().RunHook,
 		},
 		ResultSource:       rs,

--- a/pkg/v3/stores.go
+++ b/pkg/v3/stores.go
@@ -120,13 +120,11 @@ func (s *metadataStore) Set(identifiers []ocr2keepers.UpkeepIdentifier) error {
 	return nil
 }
 
-func (s *metadataStore) setBlockHistory(history ocr2keepers.BlockHistory) error {
+func (s *metadataStore) setBlockHistory(history ocr2keepers.BlockHistory) {
 	s.m.Lock()
 	defer s.m.Unlock()
 
 	s.blockHistory = history
-
-	return nil
 }
 
 func (s *metadataStore) Start() error {

--- a/pkg/v3/stores.go
+++ b/pkg/v3/stores.go
@@ -98,17 +98,14 @@ type metadataStore struct {
 	identifiers  []ocr2keepers.UpkeepIdentifier
 	blockHistory ocr2keepers.BlockHistory
 	stopCh       chan int
-	once         sync.Once
 	m            sync.RWMutex
 }
 
 func NewMetadataStore(ticker *tickers.BlockTicker) *metadataStore {
 	stopCh := make(chan int)
-	once := sync.Once{}
 	return &metadataStore{
 		ticker: ticker,
 		stopCh: stopCh,
-		once:   once,
 	}
 }
 
@@ -141,8 +138,6 @@ loop:
 }
 
 func (s *metadataStore) Stop() error {
-	s.once.Do(func() {
-		s.stopCh <- 1
-	})
+	s.stopCh <- 1
 	return nil
 }

--- a/pkg/v3/stores_test.go
+++ b/pkg/v3/stores_test.go
@@ -27,7 +27,7 @@ func (s *mockSubscriber) Unsubscribe(id int) error {
 
 func TestNewMetadataStore(t *testing.T) {
 	t.Run("sets the incoming block histories", func(t *testing.T) {
-		ch := make(chan ocr2keepers.BlockHistory)
+		ch := make(chan ocr2keepers.BlockHistory, 1)
 
 		subscriber := &mockSubscriber{
 			SubscribeFn: func() (int, chan ocr2keepers.BlockHistory, error) {

--- a/pkg/v3/stores_test.go
+++ b/pkg/v3/stores_test.go
@@ -1,0 +1,81 @@
+package ocr2keepers
+
+import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	ocr2keepers "github.com/smartcontractkit/ocr2keepers/pkg"
+	"github.com/smartcontractkit/ocr2keepers/pkg/v3/tickers"
+)
+
+type mockSubscriber struct {
+	SubscribeFn   func() (int, chan ocr2keepers.BlockHistory, error)
+	UnsubscribeFn func(id int) error
+}
+
+func (s *mockSubscriber) Subscribe() (int, chan ocr2keepers.BlockHistory, error) {
+	return s.SubscribeFn()
+}
+
+func (s *mockSubscriber) Unsubscribe(id int) error {
+	return s.UnsubscribeFn(id)
+}
+
+func TestNewMetadataStore(t *testing.T) {
+	t.Run("sets the incoming block histories", func(t *testing.T) {
+		ch := make(chan ocr2keepers.BlockHistory)
+
+		subscriber := &mockSubscriber{
+			SubscribeFn: func() (int, chan ocr2keepers.BlockHistory, error) {
+				return 0, ch, nil
+			},
+			UnsubscribeFn: func(id int) error {
+				return nil
+			},
+		}
+
+		ticker, err := tickers.NewBlockTicker(subscriber)
+		assert.NoError(t, err)
+		store := NewMetadataStore(ticker)
+
+		go func() {
+			err := ticker.Start(context.Background())
+			assert.NoError(t, err)
+		}()
+
+		go func() {
+			err := store.Start()
+			assert.NoError(t, err)
+		}()
+
+		identifiers := []ocr2keepers.UpkeepIdentifier{
+			[]byte("12|34"),
+			[]byte("56|78"),
+		}
+
+		err = store.Set(identifiers)
+		assert.NoError(t, err)
+
+		assert.True(t, reflect.DeepEqual(store.identifiers, identifiers))
+
+		history := ocr2keepers.BlockHistory{
+			ocr2keepers.BlockKey("key1"),
+		}
+
+		ch <- history
+
+		assert.Eventually(t, func() bool {
+			store.m.RLock()
+			defer store.m.RUnlock()
+			return reflect.DeepEqual(store.blockHistory, store.blockHistory)
+		}, 10*time.Second, time.Second)
+
+		err = store.Stop()
+		assert.NoError(t, err)
+
+	})
+}

--- a/pkg/v3/tickers/block.go
+++ b/pkg/v3/tickers/block.go
@@ -1,0 +1,72 @@
+package tickers
+
+import (
+	"context"
+	"log"
+	"sync"
+
+	ocr2keepers "github.com/smartcontractkit/ocr2keepers/pkg"
+)
+
+type blockSubscriber interface {
+	// Subscribe provides an identifier integer, a new channel, and potentially an error
+	Subscribe() (int, chan ocr2keepers.BlockHistory, error)
+	// Unsubscribe requires an identifier integer and indicates the provided channel should be closed
+	Unsubscribe(int) error
+}
+
+// blockTicker is a struct that follows the same design paradigm as a time ticker but provides blocks
+// instead of time
+type blockTicker struct {
+	C          chan ocr2keepers.BlockHistory
+	chID       int
+	ch         chan ocr2keepers.BlockHistory
+	subscriber blockSubscriber
+	closer     sync.Once
+	ctx        context.Context
+	cancel     context.CancelFunc
+}
+
+func NewBlockTicker(subscriber blockSubscriber) (*blockTicker, error) {
+	chID, ch, err := subscriber.Subscribe()
+	if err != nil {
+		return nil, err
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	return &blockTicker{
+		chID:       chID,
+		ch:         ch,
+		C:          make(chan ocr2keepers.BlockHistory),
+		subscriber: subscriber,
+		closer:     sync.Once{},
+		ctx:        ctx,
+		cancel:     cancel,
+	}, nil
+}
+
+func (t *blockTicker) Start(ctx context.Context) (err error) {
+loop:
+	for {
+		select {
+		case blockHistory := <-t.ch:
+			select {
+			case t.C <- blockHistory:
+				log.Print("forwarded")
+			default:
+			}
+		case <-ctx.Done():
+			err = ctx.Err()
+			break loop
+		}
+	}
+	return err
+}
+
+func (t *blockTicker) Close() {
+	t.closer.Do(func() {
+		t.cancel()
+		t.subscriber.Unsubscribe(t.chID)
+	})
+}

--- a/pkg/v3/tickers/block.go
+++ b/pkg/v3/tickers/block.go
@@ -66,7 +66,7 @@ loop:
 			if t.bufferedValue != nil {
 				select {
 				case t.C <- t.bufferedValue:
-					log.Print("forwarded fromg buffer")
+					log.Print("forwarded from buffer")
 					t.bufferedValue = nil
 				default:
 				}

--- a/pkg/v3/tickers/block.go
+++ b/pkg/v3/tickers/block.go
@@ -67,6 +67,8 @@ loop:
 func (t *blockTicker) Close() {
 	t.closer.Do(func() {
 		t.cancel()
-		t.subscriber.Unsubscribe(t.chID)
+		if err := t.subscriber.Unsubscribe(t.chID); err != nil {
+			log.Fatalf("error unsubscribing: %v", err)
+		}
 	})
 }

--- a/pkg/v3/tickers/block.go
+++ b/pkg/v3/tickers/block.go
@@ -15,9 +15,9 @@ type blockSubscriber interface {
 	Unsubscribe(int) error
 }
 
-// blockTicker is a struct that follows the same design paradigm as a time ticker but provides blocks
+// BlockTicker is a struct that follows the same design paradigm as a time ticker but provides blocks
 // instead of time
-type blockTicker struct {
+type BlockTicker struct {
 	C          chan ocr2keepers.BlockHistory
 	chID       int
 	ch         chan ocr2keepers.BlockHistory
@@ -26,13 +26,13 @@ type blockTicker struct {
 	stopCh     chan int
 }
 
-func NewBlockTicker(subscriber blockSubscriber) (*blockTicker, error) {
+func NewBlockTicker(subscriber blockSubscriber) (*BlockTicker, error) {
 	chID, ch, err := subscriber.Subscribe()
 	if err != nil {
 		return nil, err
 	}
 
-	return &blockTicker{
+	return &BlockTicker{
 		chID:       chID,
 		ch:         ch,
 		C:          make(chan ocr2keepers.BlockHistory),
@@ -42,7 +42,7 @@ func NewBlockTicker(subscriber blockSubscriber) (*blockTicker, error) {
 	}, nil
 }
 
-func (t *blockTicker) Start(ctx context.Context) (err error) {
+func (t *BlockTicker) Start(ctx context.Context) (err error) {
 loop:
 	for {
 		select {
@@ -62,7 +62,7 @@ loop:
 	return err
 }
 
-func (t *blockTicker) Close() {
+func (t *BlockTicker) Close() {
 	t.closer.Do(func() {
 		t.stopCh <- 1
 		if err := t.subscriber.Unsubscribe(t.chID); err != nil {

--- a/pkg/v3/tickers/block_test.go
+++ b/pkg/v3/tickers/block_test.go
@@ -45,7 +45,10 @@ func TestBlockTicker(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	go ticker.Start(ctx)
+	go func() {
+		err = ticker.Start(ctx)
+		assert.NoError(t, err)
+	}()
 
 	firstBlockHistory := ocr2keepers.BlockHistory{ocr2keepers.BlockKey("key 1"), ocr2keepers.BlockKey("key 2")}
 	secondBlockHistory := ocr2keepers.BlockHistory{ocr2keepers.BlockKey("key 3")}
@@ -109,7 +112,10 @@ func TestBlockTicker_cancel(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	go ticker.Start(ctx)
+	go func() {
+		err = ticker.Start(ctx)
+		assert.NoError(t, err)
+	}()
 
 	ticker.cancel()
 }

--- a/pkg/v3/tickers/block_test.go
+++ b/pkg/v3/tickers/block_test.go
@@ -149,7 +149,8 @@ func TestBlockTicker_unsubscribeError(t *testing.T) {
 	assert.Nil(t, err)
 
 	go func() {
-		ticker.Start(context.Background())
+		err = ticker.Start(context.Background())
+		assert.NoError(t, err) // context canceled
 	}()
 
 	ticker.Close()

--- a/pkg/v3/tickers/block_test.go
+++ b/pkg/v3/tickers/block_test.go
@@ -30,7 +30,7 @@ func TestBlockTicker(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	ch := make(chan ocr2keepers.BlockHistory, 1)
+	ch := make(chan ocr2keepers.BlockHistory)
 
 	sub := &mockSubscriber{
 		SubscribeFn: func() (int, chan ocr2keepers.BlockHistory, error) {
@@ -98,7 +98,7 @@ func TestBlockTicker_buffered(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	ch := make(chan ocr2keepers.BlockHistory, 1)
+	ch := make(chan ocr2keepers.BlockHistory)
 
 	sub := &mockSubscriber{
 		SubscribeFn: func() (int, chan ocr2keepers.BlockHistory, error) {
@@ -135,6 +135,7 @@ func TestBlockTicker_buffered(t *testing.T) {
 			t.Errorf("expected %v, but got %v", firstBlockHistory, got)
 		}
 		time.Sleep(100 * time.Millisecond)
+		// the third block history should be the last one received, and made availble on t.next to be sent when t.C becomes available
 		if got := <-ticker.C; !reflect.DeepEqual(thirdBlockHistory, got) {
 			t.Errorf("expected %v, but got %v", thirdBlockHistory, got)
 		}
@@ -184,22 +185,6 @@ func TestBlockTicker_subscribeError(t *testing.T) {
 	sub := &mockSubscriber{
 		SubscribeFn: func() (int, chan ocr2keepers.BlockHistory, error) {
 			return 0, nil, errors.New("subscribe failure")
-		},
-		UnsubscribeFn: func(id int) error {
-			return nil
-		},
-	}
-
-	_, err := NewBlockTicker(sub)
-	assert.Error(t, err)
-}
-
-func TestBlockTicker_unbufferedChannelError(t *testing.T) {
-	ch := make(chan ocr2keepers.BlockHistory)
-
-	sub := &mockSubscriber{
-		SubscribeFn: func() (int, chan ocr2keepers.BlockHistory, error) {
-			return 0, ch, nil
 		},
 		UnsubscribeFn: func(id int) error {
 			return nil

--- a/pkg/v3/tickers/block_test.go
+++ b/pkg/v3/tickers/block_test.go
@@ -1,0 +1,129 @@
+package tickers
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	ocr2keepers "github.com/smartcontractkit/ocr2keepers/pkg"
+)
+
+type mockSubscriber struct {
+	SubscribeFn   func() (int, chan ocr2keepers.BlockHistory, error)
+	UnsubscribeFn func(id int) error
+}
+
+func (s *mockSubscriber) Subscribe() (int, chan ocr2keepers.BlockHistory, error) {
+	return s.SubscribeFn()
+}
+
+func (s *mockSubscriber) Unsubscribe(id int) error {
+	return s.UnsubscribeFn(id)
+}
+
+func TestBlockTicker(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ch := make(chan ocr2keepers.BlockHistory)
+
+	sub := &mockSubscriber{
+		SubscribeFn: func() (int, chan ocr2keepers.BlockHistory, error) {
+			return 0, ch, nil
+		},
+		UnsubscribeFn: func(id int) error {
+			return nil
+		},
+	}
+	ticker, err := NewBlockTicker(sub)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	go ticker.Start(ctx)
+
+	firstBlockHistory := ocr2keepers.BlockHistory{ocr2keepers.BlockKey("key 1"), ocr2keepers.BlockKey("key 2")}
+	secondBlockHistory := ocr2keepers.BlockHistory{ocr2keepers.BlockKey("key 3")}
+	thirdBlockHistory := ocr2keepers.BlockHistory{ocr2keepers.BlockKey("key 4")}
+
+	blockHistories := []ocr2keepers.BlockHistory{
+		firstBlockHistory,
+		secondBlockHistory,
+		thirdBlockHistory,
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		if got := <-ticker.C; !reflect.DeepEqual(firstBlockHistory, got) {
+			t.Errorf("expected %v, but got %v", firstBlockHistory, got)
+		}
+		wg.Done()
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+
+	for _, blockHistory := range blockHistories {
+		ch <- blockHistory
+	}
+
+	wg.Wait()
+
+	wg.Add(1)
+	go func() {
+		if got := <-ticker.C; !reflect.DeepEqual(thirdBlockHistory, got) {
+			t.Errorf("expected %v, but got %v", thirdBlockHistory, got)
+		}
+		wg.Done()
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+
+	ch <- thirdBlockHistory
+
+	wg.Wait()
+	ticker.Close()
+
+}
+
+func TestBlockTicker_cancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	sub := &mockSubscriber{
+		SubscribeFn: func() (int, chan ocr2keepers.BlockHistory, error) {
+			return 0, nil, nil
+		},
+		UnsubscribeFn: func(id int) error {
+			return nil
+		},
+	}
+
+	ticker, err := NewBlockTicker(sub)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	go ticker.Start(ctx)
+
+	ticker.cancel()
+}
+
+func TestBlockTicker_subscriberError(t *testing.T) {
+	sub := &mockSubscriber{
+		SubscribeFn: func() (int, chan ocr2keepers.BlockHistory, error) {
+			return 0, nil, errors.New("subscribe failure")
+		},
+		UnsubscribeFn: func(id int) error {
+			return nil
+		},
+	}
+
+	_, err := NewBlockTicker(sub)
+	assert.Error(t, err)
+}

--- a/pkg/v3/tickers/block_test.go
+++ b/pkg/v3/tickers/block_test.go
@@ -47,7 +47,7 @@ func TestBlockTicker(t *testing.T) {
 
 	go func() {
 		err = ticker.Start(ctx)
-		assert.NoError(t, err)
+		assert.Error(t, err) // context canceled
 	}()
 
 	firstBlockHistory := ocr2keepers.BlockHistory{ocr2keepers.BlockKey("key 1"), ocr2keepers.BlockKey("key 2")}
@@ -114,7 +114,7 @@ func TestBlockTicker_cancel(t *testing.T) {
 
 	go func() {
 		err = ticker.Start(ctx)
-		assert.NoError(t, err)
+		assert.Error(t, err) // context canceled
 	}()
 
 	ticker.cancel()

--- a/pkg/v3/tickers/block_test.go
+++ b/pkg/v3/tickers/block_test.go
@@ -135,7 +135,7 @@ func TestBlockTicker_buffered(t *testing.T) {
 			t.Errorf("expected %v, but got %v", firstBlockHistory, got)
 		}
 		time.Sleep(100 * time.Millisecond)
-		// the third block history should be the last one received, and made availble on t.next to be sent when t.C becomes available
+		// the third block history should be the last one received, and made availble on t.bufferedValue to be sent when t.C becomes available
 		if got := <-ticker.C; !reflect.DeepEqual(thirdBlockHistory, got) {
 			t.Errorf("expected %v, but got %v", thirdBlockHistory, got)
 		}


### PR DESCRIPTION
In this PR, we're adding a block ticker that receives block histories from a block subscriber, and attempts to send the block history into its own channel, when available. If the ticker's channel has already received a block history, then values received from the block subscriber are discarded until the ticker's channel can be written to again.

# Buffering update

In the latest version of the code, the ticker has been updated so that:

- If the input channel (`t.ch`) can provide a value and if the output channel (`t.C`) can receive a value, the value from `t.ch` is sent into `t.C`
- If the input channel (`t.ch`) can provide a value and if the output channel (`t.C`) cannot receive a value, the value from `t.ch` is written to `t.bufferedValue`
- If the input channel (`t.ch`) cannot provide a value and if the output channel (`t.C`) can receive a value and if `t.bufferedValue` is not nil, then `t.bufferedValue` is sent into `t.C`