### PR TITLE
Log observer: pre-processing base types

### DIFF
--- a/pkg/basetypes.go
+++ b/pkg/basetypes.go
@@ -41,6 +41,22 @@ type CheckResult struct {
 	Payload   UpkeepPayload
 }
 
+type ConfiguredUpkeep struct {
+	// ID uniquely identifies the upkeep
+	ID UpkeepIdentifier
+	// Type is the event type required to initiate the upkeep
+	Type int
+	// Config is configuration data specific to the type
+	Config interface{}
+}
+
 type UpkeepPayload struct {
-	ID string // Hash uniquely identifies the upkeep payload
+	// ID uniquely identifies the upkeep payload
+	ID string
+	// Upkeep is all the information that identifies the upkeep
+	Upkeep ConfiguredUpkeep
+	// CheckData is the data used to check the upkeep
+	CheckData []byte
+	// Tick is the event that triggered the upkeep to be checked
+	Tick interface{}
 }

--- a/pkg/v3/ocrtypes_test.go
+++ b/pkg/v3/ocrtypes_test.go
@@ -18,6 +18,10 @@ func TestAutomationObservation_Encode(t *testing.T) {
 			{
 				Payload: ocr2keepers.UpkeepPayload{
 					ID: "abc",
+					Upkeep: ocr2keepers.ConfiguredUpkeep{
+						ID:   []byte("111"),
+						Type: 1,
+					},
 				},
 				Retryable: false,
 				Eligible:  false,
@@ -25,7 +29,7 @@ func TestAutomationObservation_Encode(t *testing.T) {
 		},
 	}
 
-	expectedJSON := `{"Instructions":["instruction1","instruction2"],"Metadata":{"key":"value"},"Performable":[{"Payload":{"ID":"abc"},"Retryable":false, "Eligible":false}]}`
+	expectedJSON := `{"Instructions":["instruction1","instruction2"],"Metadata":{"key":"value"},"Performable":[{"Payload":{"CheckData":null,"ID":"abc","Tick":null,"Upkeep":{"ID":"MTEx","Type":1,"Config":null}},"Retryable":false, "Eligible":false}]}`
 
 	data, err := observation.Encode()
 	assert.NoError(t, err)
@@ -66,6 +70,9 @@ func TestAutomationOutcome_Encode(t *testing.T) {
 			{
 				Payload: ocr2keepers.UpkeepPayload{
 					ID: "abc",
+					Upkeep: ocr2keepers.ConfiguredUpkeep{
+						ID: []byte("111"),
+					},
 				},
 				Retryable: false,
 				Eligible:  false,
@@ -73,7 +80,7 @@ func TestAutomationOutcome_Encode(t *testing.T) {
 		},
 	}
 
-	expectedJSON := `{"Instructions":["instruction1","instruction2"],"Metadata":{"key":"value"},"Performable":[{"Payload":{"ID":"abc"},"Retryable":false, "Eligible":false}]}`
+	expectedJSON := `{"Instructions":["instruction1","instruction2"],"Metadata":{"key":"value"},"Performable":[{"Payload":{"CheckData":null,"ID":"abc","Tick":null,"Upkeep":{"ID":"MTEx","Type":0,"Config":null}},"Retryable":false, "Eligible":false}]}`
 
 	data, err := outcome.Encode()
 	assert.NoError(t, err)


### PR DESCRIPTION
Updating `UpkeepPayload` to include all needed fields for the log event provider to construct the payload for log upkeeps. 