### PR TITLE
Add a metadata store

### DIFF
--- a/pkg/v3/plugin/ocr3.go
+++ b/pkg/v3/plugin/ocr3.go
@@ -12,13 +12,11 @@ import (
 
 type InstructionStore interface{}
 
-type SamplingStore interface{}
-
 type ocr3Plugin[RI any] struct {
 	PrebuildHooks     []func(ocr2keepersv3.AutomationOutcome) error
-	BuildHooks        []func(*ocr2keepersv3.AutomationObservation, InstructionStore, SamplingStore, ocr2keepersv3.ResultStore) error
+	BuildHooks        []func(*ocr2keepersv3.AutomationObservation, InstructionStore, ocr2keepersv3.MetadataStore, ocr2keepersv3.ResultStore) error
 	InstructionSource InstructionStore
-	MetadataSource    SamplingStore
+	MetadataSource    ocr2keepersv3.MetadataStore
 	ResultSource      ocr2keepersv3.ResultStore
 }
 

--- a/pkg/v3/plugin/ocr3_test.go
+++ b/pkg/v3/plugin/ocr3_test.go
@@ -30,7 +30,7 @@ func TestObservation(t *testing.T) {
 	plugin.PrebuildHooks = append(plugin.PrebuildHooks, mockPrebuildHook)
 
 	// Define a mock build hook function for testing build hooks
-	mockBuildHook := func(observation *ocr2keepersv3.AutomationObservation, instructionStore InstructionStore, samplingStore SamplingStore, resultStore ocr2keepersv3.ResultStore) error {
+	mockBuildHook := func(observation *ocr2keepersv3.AutomationObservation, instructionStore InstructionStore, samplingStore ocr2keepersv3.MetadataStore, resultStore ocr2keepersv3.ResultStore) error {
 		assert.Equal(t, 0, len(observation.Instructions))
 		return nil
 	}

--- a/pkg/v3/stores.go
+++ b/pkg/v3/stores.go
@@ -1,7 +1,10 @@
 package ocr2keepers
 
 import (
+	"sync"
+
 	ocr2keepers "github.com/smartcontractkit/ocr2keepers/pkg"
+	"github.com/smartcontractkit/ocr2keepers/pkg/v3/tickers"
 )
 
 // NotifyOp is an operation that can be notified by the ResultStore
@@ -21,6 +24,15 @@ type ResultStore interface {
 	Remove(...string)
 	View(...ViewOpt) ([]ocr2keepers.CheckResult, error)
 	Notifications() <-chan Notification
+}
+
+type MetadataStore interface {
+	// Set should replace any existing values
+	Set([]ocr2keepers.UpkeepIdentifier) error
+	// Start should begin watching for new block history
+	Start() error
+	// Stop should stop watching for new block heights
+	Stop() error
 }
 
 // Notification is a struct that will be sent by the ResultStore upon certain events happening
@@ -77,4 +89,60 @@ func WithLimit(limit int) ViewOpt {
 	return func(opts *viewOpts) {
 		opts.limit = limit
 	}
+}
+
+type metadataStore struct {
+	ticker       *tickers.BlockTicker
+	identifiers  []ocr2keepers.UpkeepIdentifier
+	blockHistory ocr2keepers.BlockHistory
+	stopCh       chan int
+	once         sync.Once
+	m            sync.RWMutex
+}
+
+func NewMetadataStore(ticker *tickers.BlockTicker) *metadataStore {
+	stopCh := make(chan int)
+	once := sync.Once{}
+	return &metadataStore{
+		ticker: ticker,
+		stopCh: stopCh,
+		once:   once,
+	}
+}
+
+func (s *metadataStore) Set(identifiers []ocr2keepers.UpkeepIdentifier) error {
+	s.m.Lock()
+	defer s.m.Unlock()
+
+	s.identifiers = identifiers
+	return nil
+}
+
+func (s *metadataStore) setBlockHistory(history ocr2keepers.BlockHistory) error {
+	s.m.Lock()
+	defer s.m.Unlock()
+
+	s.blockHistory = history
+
+	return nil
+}
+
+func (s *metadataStore) Start() error {
+loop:
+	for {
+		select {
+		case blockHistory := <-s.ticker.C:
+			s.setBlockHistory(blockHistory)
+		case <-s.stopCh:
+			break loop
+		}
+	}
+	return nil
+}
+
+func (s *metadataStore) Stop() error {
+	s.once.Do(func() {
+		s.stopCh <- 1
+	})
+	return nil
 }

--- a/pkg/v3/stores_test.go
+++ b/pkg/v3/stores_test.go
@@ -1,0 +1,81 @@
+package ocr2keepers
+
+import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	ocr2keepers "github.com/smartcontractkit/ocr2keepers/pkg"
+	"github.com/smartcontractkit/ocr2keepers/pkg/v3/tickers"
+)
+
+type mockSubscriber struct {
+	SubscribeFn   func() (int, chan ocr2keepers.BlockHistory, error)
+	UnsubscribeFn func(id int) error
+}
+
+func (s *mockSubscriber) Subscribe() (int, chan ocr2keepers.BlockHistory, error) {
+	return s.SubscribeFn()
+}
+
+func (s *mockSubscriber) Unsubscribe(id int) error {
+	return s.UnsubscribeFn(id)
+}
+
+func TestNewMetadataStore(t *testing.T) {
+	t.Run("sets the incoming block histories", func(t *testing.T) {
+		ch := make(chan ocr2keepers.BlockHistory)
+
+		subscriber := &mockSubscriber{
+			SubscribeFn: func() (int, chan ocr2keepers.BlockHistory, error) {
+				return 0, ch, nil
+			},
+			UnsubscribeFn: func(id int) error {
+				return nil
+			},
+		}
+
+		ticker, err := tickers.NewBlockTicker(subscriber)
+		assert.NoError(t, err)
+		store := NewMetadataStore(ticker)
+
+		go func() {
+			err := ticker.Start(context.Background())
+			assert.NoError(t, err)
+		}()
+
+		go func() {
+			err := store.Start()
+			assert.NoError(t, err)
+		}()
+
+		identifiers := []ocr2keepers.UpkeepIdentifier{
+			[]byte("12|34"),
+			[]byte("56|78"),
+		}
+
+		err = store.Set(identifiers)
+		assert.NoError(t, err)
+
+		assert.True(t, reflect.DeepEqual(store.identifiers, identifiers))
+
+		history := ocr2keepers.BlockHistory{
+			ocr2keepers.BlockKey("key1"),
+		}
+
+		ch <- history
+
+		assert.Eventually(t, func() bool {
+			store.m.RLock()
+			defer store.m.RUnlock()
+			return reflect.DeepEqual(store.blockHistory, store.blockHistory)
+		}, 10*time.Second, time.Second)
+
+		err = store.Stop()
+		assert.NoError(t, err)
+
+	})
+}

--- a/pkg/v3/tickers/block.go
+++ b/pkg/v3/tickers/block.go
@@ -15,9 +15,9 @@ type blockSubscriber interface {
 	Unsubscribe(int) error
 }
 
-// blockTicker is a struct that follows the same design paradigm as a time ticker but provides blocks
+// BlockTicker is a struct that follows the same design paradigm as a time ticker but provides blocks
 // instead of time
-type blockTicker struct {
+type BlockTicker struct {
 	C          chan ocr2keepers.BlockHistory
 	chID       int
 	ch         chan ocr2keepers.BlockHistory
@@ -26,13 +26,13 @@ type blockTicker struct {
 	stopCh     chan int
 }
 
-func NewBlockTicker(subscriber blockSubscriber) (*blockTicker, error) {
+func NewBlockTicker(subscriber blockSubscriber) (*BlockTicker, error) {
 	chID, ch, err := subscriber.Subscribe()
 	if err != nil {
 		return nil, err
 	}
 
-	return &blockTicker{
+	return &BlockTicker{
 		chID:       chID,
 		ch:         ch,
 		C:          make(chan ocr2keepers.BlockHistory),
@@ -42,7 +42,7 @@ func NewBlockTicker(subscriber blockSubscriber) (*blockTicker, error) {
 	}, nil
 }
 
-func (t *blockTicker) Start(ctx context.Context) (err error) {
+func (t *BlockTicker) Start(ctx context.Context) (err error) {
 loop:
 	for {
 		select {
@@ -62,7 +62,7 @@ loop:
 	return err
 }
 
-func (t *blockTicker) Close() {
+func (t *BlockTicker) Close() {
 	t.closer.Do(func() {
 		t.stopCh <- 1
 		if err := t.subscriber.Unsubscribe(t.chID); err != nil {


### PR DESCRIPTION
In this PR, we're renaming the SamplingStore to the MetadataStore, and implementing the respective functionality. When the MetadataStore runs, we listen to a block ticker and retrieve BlockHistory slices. The BlockHistory slice overwrites the locally stored BlockHistory slice. A set function has been added that lets us store a slice of upkeep IDs.