### PR TITLE
Outcome generation

### DIFF
--- a/pkg/v3/plugin/ocr3.go
+++ b/pkg/v3/plugin/ocr3.go
@@ -83,7 +83,7 @@ func (plugin *ocr3Plugin[RI]) Outcome(outctx ocr3types.OutcomeContext, query typ
 		}
 
 		for _, result := range observation.Performable {
-			uid := fmt.Sprintf("%v", result.Payload)
+			uid := fmt.Sprintf("%v", result)
 			payloadCount, ok := resultCount[uid]
 			if !ok {
 				payloadCount = resultAndCount{

--- a/pkg/v3/plugin/ocr3.go
+++ b/pkg/v3/plugin/ocr3.go
@@ -12,8 +12,6 @@ import (
 	ocr2keepersv3 "github.com/smartcontractkit/ocr2keepers/pkg/v3"
 )
 
-var ErrNotEnoughInputs = fmt.Errorf("not enough inputs")
-
 type InstructionStore interface{}
 
 type SamplingStore interface{}

--- a/pkg/v3/plugin/ocr3.go
+++ b/pkg/v3/plugin/ocr3.go
@@ -74,7 +74,6 @@ func (plugin *ocr3Plugin[RI]) Outcome(outctx ocr3types.OutcomeContext, query typ
 		count  int
 	}
 
-	submittedObservations := len(attributedObservations)
 	resultCount := make(map[string]resultAndCount)
 
 	for _, attributedObservation := range attributedObservations {
@@ -98,6 +97,7 @@ func (plugin *ocr3Plugin[RI]) Outcome(outctx ocr3types.OutcomeContext, query typ
 		}
 	}
 
+	submittedObservations := len(attributedObservations)
 	quorumThreshold := submittedObservations / 2
 
 	var performable []ocr2keepers.CheckResult

--- a/pkg/v3/plugin/ocr3.go
+++ b/pkg/v3/plugin/ocr3.go
@@ -71,10 +71,6 @@ func (plugin *ocr3Plugin[RI]) ValidateObservation(outctx ocr3types.OutcomeContex
 }
 
 func (plugin *ocr3Plugin[RI]) Outcome(outctx ocr3types.OutcomeContext, query types.Query, attributedObservations []types.AttributedObservation) (ocr3types.Outcome, error) {
-	if len(attributedObservations) == 0 {
-		return nil, fmt.Errorf("%w: must provide at least 1 observation", ErrNotEnoughInputs)
-	}
-
 	type resultAndCount struct {
 		result ocr2keepers.CheckResult
 		count  int
@@ -90,7 +86,6 @@ func (plugin *ocr3Plugin[RI]) Outcome(outctx ocr3types.OutcomeContext, query typ
 		}
 
 		for _, result := range observation.Performable {
-			// TODO should the eligible and retryable fields be included here?
 			uid := fmt.Sprintf("%v", result.Payload)
 			payloadCount, ok := resultCount[uid]
 			if !ok {
@@ -105,7 +100,6 @@ func (plugin *ocr3Plugin[RI]) Outcome(outctx ocr3types.OutcomeContext, query typ
 		}
 	}
 
-	// TODO what should the threshold be for including a result
 	quorumThreshold := submittedObservations / 2
 
 	var performable []ocr2keepers.CheckResult

--- a/pkg/v3/plugin/ocr3_test.go
+++ b/pkg/v3/plugin/ocr3_test.go
@@ -72,7 +72,7 @@ func TestOcr3Plugin_Outcome(t *testing.T) {
 		assert.Error(t, err)
 	})
 
-	t.Run("given three observations, in which two only differ in retryable and eligible status, one observations is added to the outcome", func(t *testing.T) {
+	t.Run("given three observations, in which two are identical, one observations is added to the outcome", func(t *testing.T) {
 		// Create an instance of ocr3 plugin
 		plugin := &ocr3Plugin[int]{}
 
@@ -104,8 +104,8 @@ func TestOcr3Plugin_Outcome(t *testing.T) {
 		automationObservation2 := ocr2keepersv3.AutomationObservation{
 			Performable: []ocr2keepers.CheckResult{
 				{
-					Eligible:  false,
-					Retryable: true,
+					Eligible:  true,
+					Retryable: false,
 					Payload: ocr2keepers.UpkeepPayload{
 						ID: "123",
 						Upkeep: ocr2keepers.ConfiguredUpkeep{
@@ -167,8 +167,7 @@ func TestOcr3Plugin_Outcome(t *testing.T) {
 		automationOutcome, err := ocr2keepersv3.DecodeAutomationOutcome(outcome)
 		assert.NoError(t, err)
 
-		// obs2 only differs from obs1 in eligible and retryable values, which are not included in the hash value, so
-		// they will be considered the same result
+		// obs1 and obs2 are identical, so they will be considered the same result. obs3 doesn't reach the quorum threshold
 		assert.Len(t, automationOutcome.Performable, 1)
 	})
 }

--- a/pkg/v3/plugin/ocr3_test.go
+++ b/pkg/v3/plugin/ocr3_test.go
@@ -52,20 +52,6 @@ func TestObservation(t *testing.T) {
 }
 
 func TestOcr3Plugin_Outcome(t *testing.T) {
-	t.Run("empty observations returns an error", func(t *testing.T) {
-		// Create an instance of ocr3 plugin
-		plugin := &ocr3Plugin[int]{}
-
-		// Create a sample outcome for decoding
-		outcomeContext := ocr3types.OutcomeContext{
-			PreviousOutcome: []byte(`{"Instructions":["instruction1"],"Metadata":{"key":"value"},"Performable":[]}`),
-		}
-
-		outcome, err := plugin.Outcome(outcomeContext, nil, nil)
-		assert.Nil(t, outcome)
-		assert.Error(t, err)
-	})
-
 	t.Run("malformed observations returns an error", func(t *testing.T) {
 		// Create an instance of ocr3 plugin
 		plugin := &ocr3Plugin[int]{}

--- a/pkg/v3/plugin/ocr3_test.go
+++ b/pkg/v3/plugin/ocr3_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 	"github.com/stretchr/testify/assert"
 
+	ocr2keepers "github.com/smartcontractkit/ocr2keepers/pkg"
 	ocr2keepersv3 "github.com/smartcontractkit/ocr2keepers/pkg/v3"
 )
 
@@ -48,4 +49,140 @@ func TestObservation(t *testing.T) {
 	// Assert that the returned observation matches the expected encoded outcome
 	expectedEncodedOutcome := []byte(`{"Instructions":null,"Metadata":null,"Performable":null}`)
 	assert.Equal(t, types.Observation(expectedEncodedOutcome), observation)
+}
+
+func TestOcr3Plugin_Outcome(t *testing.T) {
+	t.Run("empty observations returns an error", func(t *testing.T) {
+		// Create an instance of ocr3 plugin
+		plugin := &ocr3Plugin[int]{}
+
+		// Create a sample outcome for decoding
+		outcomeContext := ocr3types.OutcomeContext{
+			PreviousOutcome: []byte(`{"Instructions":["instruction1"],"Metadata":{"key":"value"},"Performable":[]}`),
+		}
+
+		outcome, err := plugin.Outcome(outcomeContext, nil, nil)
+		assert.Nil(t, outcome)
+		assert.Error(t, err)
+	})
+
+	t.Run("malformed observations returns an error", func(t *testing.T) {
+		// Create an instance of ocr3 plugin
+		plugin := &ocr3Plugin[int]{}
+
+		// Create a sample outcome for decoding
+		outcomeContext := ocr3types.OutcomeContext{
+			PreviousOutcome: []byte(`{"Instructions":["instruction1"],"Metadata":{"key":"value"},"Performable":[]}`),
+		}
+
+		observations := []types.AttributedObservation{
+			{
+				Observation: []byte("malformed"),
+			},
+		}
+
+		outcome, err := plugin.Outcome(outcomeContext, nil, observations)
+		assert.Nil(t, outcome)
+		assert.Error(t, err)
+	})
+
+	t.Run("given three observations, in which two only differ in retryable and eligible status, one observations is added to the outcome", func(t *testing.T) {
+		// Create an instance of ocr3 plugin
+		plugin := &ocr3Plugin[int]{}
+
+		// Create a sample outcome for decoding
+		outcomeContext := ocr3types.OutcomeContext{
+			PreviousOutcome: []byte(`{"Instructions":["instruction1"],"Metadata":{"key":"value"},"Performable":[]}`),
+		}
+
+		automationObservation1 := ocr2keepersv3.AutomationObservation{
+			Performable: []ocr2keepers.CheckResult{
+				{
+					Eligible:  true,
+					Retryable: false,
+					Payload: ocr2keepers.UpkeepPayload{
+						ID: "123",
+						Upkeep: ocr2keepers.ConfiguredUpkeep{
+							ID:   ocr2keepers.UpkeepIdentifier("456"),
+							Type: 1,
+						},
+						Trigger: ocr2keepers.Trigger{
+							BlockNumber: 987,
+							BlockHash:   "789",
+							Extension:   333,
+						},
+					},
+				},
+			},
+		}
+		automationObservation2 := ocr2keepersv3.AutomationObservation{
+			Performable: []ocr2keepers.CheckResult{
+				{
+					Eligible:  false,
+					Retryable: true,
+					Payload: ocr2keepers.UpkeepPayload{
+						ID: "123",
+						Upkeep: ocr2keepers.ConfiguredUpkeep{
+							ID:   ocr2keepers.UpkeepIdentifier("456"),
+							Type: 1,
+						},
+						Trigger: ocr2keepers.Trigger{
+							BlockNumber: 987,
+							BlockHash:   "789",
+							Extension:   333,
+						},
+					},
+				},
+			},
+		}
+		automationObservation3 := ocr2keepersv3.AutomationObservation{
+			Performable: []ocr2keepers.CheckResult{
+				{
+					Eligible:  true,
+					Retryable: false,
+					Payload: ocr2keepers.UpkeepPayload{
+						ID: "112233",
+						Upkeep: ocr2keepers.ConfiguredUpkeep{
+							ID:   ocr2keepers.UpkeepIdentifier("456"),
+							Type: 1,
+						},
+						Trigger: ocr2keepers.Trigger{
+							BlockNumber: 987,
+							BlockHash:   "789",
+							Extension:   333,
+						},
+					},
+				},
+			},
+		}
+
+		obs1, err := automationObservation1.Encode()
+		assert.NoError(t, err)
+		obs2, err := automationObservation2.Encode()
+		assert.NoError(t, err)
+		obs3, err := automationObservation3.Encode()
+		assert.NoError(t, err)
+
+		observations := []types.AttributedObservation{
+			{
+				Observation: obs1,
+			},
+			{
+				Observation: obs2, // payload matches obs1, giving 2 counts of the same payload
+			},
+			{
+				Observation: obs3, // this single report instance won't reach the quorum threshold
+			},
+		}
+
+		outcome, err := plugin.Outcome(outcomeContext, nil, observations)
+		assert.NoError(t, err)
+
+		automationOutcome, err := ocr2keepersv3.DecodeAutomationOutcome(outcome)
+		assert.NoError(t, err)
+
+		// obs2 only differs from obs1 in eligible and retryable values, which are not included in the hash value, so
+		// they will be considered the same result
+		assert.Len(t, automationOutcome.Performable, 1)
+	})
 }


### PR DESCRIPTION
In this PR, we're implementing the `Outcome` function of the v3 plugin

In this function, we receive a list of `AttributedObservations`. We decode each observation, and we count the unique instances of each `PerformableResult` in the observation. 

Every performable result is comprised of three fields:

- Eligible (bool)
- Retryable (bool)
- Payload (UpkeepPayload)

However, only the `Payload` field is used to distinguish one performable result from another; or to put it another way, the Eligible and Retryable fields are ignored in the uniqueness comparison, and only the Payloads of two performable results are compared to determine if they are the same performable result or not.

Once the number of unique performable results has been calculated, we copy any result that exceeds the quorum threshold (`= number of attributed observations / 2`) into the outcome.