### PR TITLE
Empty Delegate constructor

### DIFF
--- a/pkg/v3/plugin/delegate.go
+++ b/pkg/v3/plugin/delegate.go
@@ -1,0 +1,49 @@
+package plugin
+
+import (
+	"context"
+
+	"github.com/smartcontractkit/libocr/commontypes"
+	"github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3types"
+	"github.com/smartcontractkit/libocr/offchainreporting2plus/types"
+)
+
+// DelegateConfig provides a single configuration struct for all options
+// to be passed to the oracle, oracle factory, and underlying plugin/services.
+type DelegateConfig struct {
+	BinaryNetworkEndpointFactory types.BinaryNetworkEndpointFactory
+	V2Bootstrappers              []commontypes.BootstrapperLocator
+	ContractConfigTracker        types.ContractConfigTracker
+	ContractTransmitter          types.ContractTransmitter
+	KeepersDatabase              ocr3types.Database
+	Logger                       commontypes.Logger
+	MonitoringEndpoint           commontypes.MonitoringEndpoint
+	OffchainConfigDigester       types.OffchainConfigDigester
+	OffchainKeyring              types.OffchainKeyring
+	OnchainKeyring               types.OnchainKeyring
+	LocalConfig                  types.LocalConfig
+}
+
+// Delegate is a container struct for an Oracle plugin. This struct provides
+// the ability to start and stop underlying services associated with the
+// plugin instance.
+type Delegate struct{}
+
+// NewDelegate provides a new Delegate from a provided config. A new logger
+// is defined that wraps the configured logger with a default Go logger.
+// The plugin uses a *log.Logger by default so all log output from the
+// built-in logger are written to the provided logger as Debug logs prefaced
+// with '[keepers-plugin] ' and a short file name.
+func NewDelegate(c DelegateConfig) (*Delegate, error) {
+	return &Delegate{}, nil
+}
+
+// Start starts the OCR oracle and any associated services
+func (d *Delegate) Start(_ context.Context) error {
+	return nil
+}
+
+// Close stops the OCR oracle and any associated services
+func (d *Delegate) Close() error {
+	return nil
+}

--- a/pkg/v3/plugin/delegate.go
+++ b/pkg/v3/plugin/delegate.go
@@ -4,8 +4,11 @@ import (
 	"context"
 
 	"github.com/smartcontractkit/libocr/commontypes"
+	offchainreporting "github.com/smartcontractkit/libocr/offchainreporting2plus"
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3types"
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/types"
+	"github.com/smartcontractkit/ocr2keepers/pkg/v3/coordinator"
+	"github.com/smartcontractkit/ocr2keepers/pkg/v3/flows"
 )
 
 // DelegateConfig provides a single configuration struct for all options
@@ -22,12 +25,23 @@ type DelegateConfig struct {
 	OffchainKeyring              types.OffchainKeyring
 	OnchainKeyring               types.OnchainKeyring
 	LocalConfig                  types.LocalConfig
+
+	// LogProvider allows reads on the latest log events ready to be processed
+	LogProvider flows.LogEventProvider
+
+	// EventProvider allows reads on latest transmit events
+	EventProvider coordinator.EventProvider
+
+	// Encoder provides methods to encode/decode reports
+	Encoder Encoder
 }
 
 // Delegate is a container struct for an Oracle plugin. This struct provides
 // the ability to start and stop underlying services associated with the
 // plugin instance.
-type Delegate struct{}
+type Delegate struct {
+	keeper *offchainreporting.Oracle
+}
 
 // NewDelegate provides a new Delegate from a provided config. A new logger
 // is defined that wraps the configured logger with a default Go logger.
@@ -35,7 +49,8 @@ type Delegate struct{}
 // built-in logger are written to the provided logger as Debug logs prefaced
 // with '[keepers-plugin] ' and a short file name.
 func NewDelegate(c DelegateConfig) (*Delegate, error) {
-	return &Delegate{}, nil
+
+	return &Delegate{keeper: nil}, nil
 }
 
 // Start starts the OCR oracle and any associated services

--- a/pkg/v3/plugin/delegate.go
+++ b/pkg/v3/plugin/delegate.go
@@ -4,9 +4,9 @@ import (
 	"context"
 
 	"github.com/smartcontractkit/libocr/commontypes"
-	offchainreporting "github.com/smartcontractkit/libocr/offchainreporting2plus"
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3types"
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/types"
+
 	"github.com/smartcontractkit/ocr2keepers/pkg/v3/coordinator"
 	"github.com/smartcontractkit/ocr2keepers/pkg/v3/flows"
 )
@@ -40,7 +40,6 @@ type DelegateConfig struct {
 // the ability to start and stop underlying services associated with the
 // plugin instance.
 type Delegate struct {
-	keeper *offchainreporting.Oracle
 }
 
 // NewDelegate provides a new Delegate from a provided config. A new logger
@@ -50,7 +49,7 @@ type Delegate struct {
 // with '[keepers-plugin] ' and a short file name.
 func NewDelegate(c DelegateConfig) (*Delegate, error) {
 
-	return &Delegate{keeper: nil}, nil
+	return &Delegate{}, nil
 }
 
 // Start starts the OCR oracle and any associated services

--- a/pkg/v3/plugin/ocr3.go
+++ b/pkg/v3/plugin/ocr3.go
@@ -219,6 +219,7 @@ func (plugin *ocr3Plugin[RI]) Close() error {
 	return err
 }
 
+// this start function should not block
 func (plugin *ocr3Plugin[RI]) startServices() {
 	for i := range plugin.Services {
 		go func(svc service.Recoverable) {


### PR DESCRIPTION
This commit adds a new delegate constructor to hook the plugin into the core node. Currently it does not correctly construct a functional delegate since that does not yet exist in libocr.