### PR TITLE
Add coordinate block prebuild and build hooks

### DIFF
--- a/pkg/v3/hooks/build/add_from_staging.go
+++ b/pkg/v3/hooks/build/add_from_staging.go
@@ -6,16 +6,16 @@ import (
 	ocr2keepersv3 "github.com/smartcontractkit/ocr2keepers/pkg/v3"
 )
 
-func NewBuildHookAddFromStaging(rStore ocr2keepersv3.ResultStore, logger *log.Logger) *BuildHookAddFromStaging {
-	return &BuildHookAddFromStaging{rStore: rStore, logger: logger}
+func NewAddFromStaging(rStore ocr2keepersv3.ResultStore, logger *log.Logger) *AddFromStaging {
+	return &AddFromStaging{rStore: rStore, logger: logger}
 }
 
-type BuildHookAddFromStaging struct {
+type AddFromStaging struct {
 	rStore ocr2keepersv3.ResultStore
 	logger *log.Logger
 }
 
-func (hook *BuildHookAddFromStaging) RunHook(obs *ocr2keepersv3.AutomationObservation) error {
+func (hook *AddFromStaging) RunHook(obs *ocr2keepersv3.AutomationObservation) error {
 	results, err := hook.rStore.View()
 	if err != nil {
 		return err

--- a/pkg/v3/hooks/build/add_from_staging.go
+++ b/pkg/v3/hooks/build/add_from_staging.go
@@ -1,4 +1,4 @@
-package hooks
+package build
 
 import (
 	"log"

--- a/pkg/v3/hooks/build/add_from_staging_test.go
+++ b/pkg/v3/hooks/build/add_from_staging_test.go
@@ -1,14 +1,15 @@
-package hooks
+package build
 
 import (
 	"io"
 	"log"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	ocr2keepers "github.com/smartcontractkit/ocr2keepers/pkg"
 	ocr2keepersv3 "github.com/smartcontractkit/ocr2keepers/pkg/v3"
 	"github.com/smartcontractkit/ocr2keepers/pkg/v3/resultstore"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestBuildHookAddFromStaging(t *testing.T) {

--- a/pkg/v3/hooks/build/add_from_staging_test.go
+++ b/pkg/v3/hooks/build/add_from_staging_test.go
@@ -12,9 +12,9 @@ import (
 	"github.com/smartcontractkit/ocr2keepers/pkg/v3/resultstore"
 )
 
-func TestBuildHookAddFromStaging(t *testing.T) {
+func TestAddFromStaging(t *testing.T) {
 	rs := resultstore.New(log.New(io.Discard, "", 0))
-	hook := NewBuildHookAddFromStaging(rs, log.New(io.Discard, "", 0))
+	hook := NewAddFromStaging(rs, log.New(io.Discard, "", 0))
 	observation := &ocr2keepersv3.AutomationObservation{}
 	expected := []ocr2keepers.CheckResult{
 		{Payload: ocr2keepers.UpkeepPayload{ID: "test1"}},

--- a/pkg/v3/hooks/build/coordinate_block.go
+++ b/pkg/v3/hooks/build/coordinate_block.go
@@ -1,0 +1,30 @@
+package build
+
+import (
+	ocr2keepers "github.com/smartcontractkit/ocr2keepers/pkg/v3"
+	"github.com/smartcontractkit/ocr2keepers/pkg/v3/flows"
+	"github.com/smartcontractkit/ocr2keepers/pkg/v3/instruction"
+)
+
+const (
+	ShouldCoordinateBlock instruction.Instruction = "should coordinate block"
+	DoCoordinateBlock     instruction.Instruction = "do coordinate block"
+)
+
+type BuildHook func(*ocr2keepers.AutomationObservation, instruction.InstructionStore, ocr2keepers.MetadataStore, flows.ResultStore) error
+
+type coordinateBlockHook struct{}
+
+func NewCoordinateBlockHook() *coordinateBlockHook {
+	return &coordinateBlockHook{}
+}
+
+func (h *coordinateBlockHook) RunHook(obs *ocr2keepers.AutomationObservation, instructionStore instruction.InstructionStore, metadataStore ocr2keepers.MetadataStore, resultStore flows.ResultStore) error {
+	if instructionStore.Has(ShouldCoordinateBlock) {
+		obs.Instructions = append(obs.Instructions, ShouldCoordinateBlock)
+	} else if instructionStore.Has(DoCoordinateBlock) {
+		obs.Metadata["blockHistory"] = metadataStore.GetBlockHistory()
+	}
+
+	return nil
+}

--- a/pkg/v3/hooks/build/coordinate_block_test.go
+++ b/pkg/v3/hooks/build/coordinate_block_test.go
@@ -1,0 +1,157 @@
+package build_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	ocr2keepers2 "github.com/smartcontractkit/ocr2keepers/pkg"
+	ocr2keepers "github.com/smartcontractkit/ocr2keepers/pkg/v3"
+	"github.com/smartcontractkit/ocr2keepers/pkg/v3/hooks/build"
+	"github.com/smartcontractkit/ocr2keepers/pkg/v3/instruction"
+	"github.com/smartcontractkit/ocr2keepers/pkg/v3/tickers"
+)
+
+type mockInstructionStore struct {
+	SetFn    func(instruction.Instruction)
+	HasFn    func(instruction.Instruction) bool
+	DeleteFn func(instruction.Instruction)
+}
+
+func (s *mockInstructionStore) Set(i instruction.Instruction) {
+	s.SetFn(i)
+}
+
+func (s *mockInstructionStore) Has(i instruction.Instruction) bool {
+	return s.HasFn(i)
+}
+
+func (s *mockInstructionStore) Delete(i instruction.Instruction) {
+	s.DeleteFn(i)
+}
+
+type mockSubscriber struct {
+	SubscribeFn   func() (int, chan ocr2keepers2.BlockHistory, error)
+	UnsubscribeFn func(id int) error
+}
+
+func (s *mockSubscriber) Subscribe() (int, chan ocr2keepers2.BlockHistory, error) {
+	return s.SubscribeFn()
+}
+
+func (s *mockSubscriber) Unsubscribe(id int) error {
+	return s.UnsubscribeFn(id)
+}
+
+func TestNewCoordinateBlockHook(t *testing.T) {
+	t.Run("when the instruction store has the should coordinate block instruction, the observation gets updated with should coordinate block instruction", func(t *testing.T) {
+		hook := build.NewCoordinateBlockHook()
+		obs := &ocr2keepers.AutomationObservation{
+			Instructions: []instruction.Instruction{},
+			Metadata:     map[string]interface{}{},
+			Performable:  []ocr2keepers2.CheckResult{},
+		}
+
+		instructionStoreMap := map[instruction.Instruction]bool{}
+
+		instructionStore := &mockInstructionStore{
+			SetFn: func(i instruction.Instruction) {
+				instructionStoreMap[i] = true
+			},
+			HasFn: func(i instruction.Instruction) bool {
+				return instructionStoreMap[i]
+			},
+			DeleteFn: func(i instruction.Instruction) {
+				delete(instructionStoreMap, i)
+			},
+		}
+
+		ch := make(chan ocr2keepers2.BlockHistory)
+
+		subscriber := &mockSubscriber{
+			SubscribeFn: func() (int, chan ocr2keepers2.BlockHistory, error) {
+				return 0, ch, nil
+			},
+			UnsubscribeFn: func(id int) error {
+				return nil
+			},
+		}
+
+		ticker, err := tickers.NewBlockTicker(subscriber)
+		assert.NoError(t, err)
+
+		metadataStore := ocr2keepers.NewMetadataStore(ticker)
+
+		instructionStore.Set(build.ShouldCoordinateBlock)
+		assert.Equal(t, 0, len(obs.Instructions))
+		err = hook.RunHook(obs, instructionStore, metadataStore, nil)
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(obs.Instructions))
+		assert.Equal(t, obs.Instructions[0], build.ShouldCoordinateBlock)
+	})
+
+	t.Run("when the instruction store has the do coordinate block instruction, the observation gets updated with the block history", func(t *testing.T) {
+		hook := build.NewCoordinateBlockHook()
+		obs := &ocr2keepers.AutomationObservation{
+			Instructions: []instruction.Instruction{},
+			Metadata:     map[string]interface{}{},
+			Performable:  []ocr2keepers2.CheckResult{},
+		}
+
+		instructionStoreMap := map[instruction.Instruction]bool{}
+
+		instructionStore := &mockInstructionStore{
+			SetFn: func(i instruction.Instruction) {
+				instructionStoreMap[i] = true
+			},
+			HasFn: func(i instruction.Instruction) bool {
+				return instructionStoreMap[i]
+			},
+			DeleteFn: func(i instruction.Instruction) {
+				delete(instructionStoreMap, i)
+			},
+		}
+
+		ch := make(chan ocr2keepers2.BlockHistory)
+
+		subscriber := &mockSubscriber{
+			SubscribeFn: func() (int, chan ocr2keepers2.BlockHistory, error) {
+				return 0, ch, nil
+			},
+			UnsubscribeFn: func(id int) error {
+				return nil
+			},
+		}
+
+		ticker, err := tickers.NewBlockTicker(subscriber)
+		assert.NoError(t, err)
+
+		metadataStore := ocr2keepers.NewMetadataStore(ticker)
+
+		blockHistory := ocr2keepers2.BlockHistory{
+			ocr2keepers2.BlockKey("1"),
+			ocr2keepers2.BlockKey("2"),
+			ocr2keepers2.BlockKey("3"),
+		}
+
+		go func() {
+			err = metadataStore.Start()
+			assert.NoError(t, err)
+		}()
+		go func() {
+			err = ticker.Start(context.Background())
+			assert.NoError(t, err)
+		}()
+
+		ch <- blockHistory
+
+		time.Sleep(1 * time.Second)
+
+		instructionStore.Set(build.DoCoordinateBlock)
+		err = hook.RunHook(obs, instructionStore, metadataStore, nil)
+		assert.NoError(t, err)
+		assert.Equal(t, obs.Metadata["blockHistory"], blockHistory)
+	})
+}

--- a/pkg/v3/hooks/prebuild/coordinate_block.go
+++ b/pkg/v3/hooks/prebuild/coordinate_block.go
@@ -1,0 +1,55 @@
+package prebuild
+
+import (
+	"errors"
+
+	ocr2keepers "github.com/smartcontractkit/ocr2keepers/pkg"
+	ocr2keepersv3 "github.com/smartcontractkit/ocr2keepers/pkg/v3"
+	"github.com/smartcontractkit/ocr2keepers/pkg/v3/instruction"
+)
+
+const (
+	ShouldCoordinateBlock instruction.Instruction = "should coordinate block"
+	DoCoordinateBlock     instruction.Instruction = "do coordinate block"
+)
+
+type coordinatedBlockSetter interface {
+	SetBlock(key ocr2keepers.BlockKey)
+}
+
+type coordinateBlockHook struct {
+	instructionStore instruction.InstructionStore
+	blockSetter      coordinatedBlockSetter
+}
+
+func NewCoordinateBlockHook(instructionStore instruction.InstructionStore, blockSetter coordinatedBlockSetter) *coordinateBlockHook {
+	return &coordinateBlockHook{
+		instructionStore: instructionStore,
+		blockSetter:      blockSetter,
+	}
+}
+
+func (h *coordinateBlockHook) RunHook(outcome ocr2keepersv3.AutomationOutcome) error {
+	for _, instruction := range outcome.Instructions {
+		if instruction == ShouldCoordinateBlock {
+			h.instructionStore.Set(DoCoordinateBlock)
+			h.instructionStore.Delete(ShouldCoordinateBlock)
+			break
+		}
+	}
+
+loop:
+	for k, v := range outcome.Metadata {
+		if k == "coordinatedBlock" {
+			switch t := v.(type) {
+			case ocr2keepers.BlockKey:
+				h.blockSetter.SetBlock(t)
+				break loop
+			default:
+				return errors.New("coordinated block is unexpected type")
+			}
+		}
+	}
+
+	return nil
+}

--- a/pkg/v3/hooks/prebuild/coordinate_block_test.go
+++ b/pkg/v3/hooks/prebuild/coordinate_block_test.go
@@ -1,0 +1,128 @@
+package prebuild
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	ocr2keepers2 "github.com/smartcontractkit/ocr2keepers/pkg"
+	ocr2keepers "github.com/smartcontractkit/ocr2keepers/pkg/v3"
+	"github.com/smartcontractkit/ocr2keepers/pkg/v3/instruction"
+)
+
+type mockInstructionStore struct {
+	SetFn    func(instruction.Instruction)
+	HasFn    func(instruction.Instruction) bool
+	DeleteFn func(instruction.Instruction)
+}
+
+func (s *mockInstructionStore) Set(i instruction.Instruction) {
+	s.SetFn(i)
+}
+
+func (s *mockInstructionStore) Has(i instruction.Instruction) bool {
+	return s.HasFn(i)
+}
+
+func (s *mockInstructionStore) Delete(i instruction.Instruction) {
+	s.DeleteFn(i)
+}
+
+type mockBlockSetter struct {
+	SetBlockFn func(key ocr2keepers2.BlockKey)
+}
+
+func (s *mockBlockSetter) SetBlock(key ocr2keepers2.BlockKey) {
+	s.SetBlockFn(key)
+}
+
+func TestNewCoordinateBlockHook(t *testing.T) {
+	t.Run("pre build hook adds DoCoordinateBlock to the instruction store", func(t *testing.T) {
+		storeState := make(map[instruction.Instruction]bool)
+		store := &mockInstructionStore{
+			SetFn: func(i instruction.Instruction) {
+				storeState[i] = true
+			},
+			DeleteFn: func(i instruction.Instruction) {
+				delete(storeState, i)
+			},
+			HasFn: func(i instruction.Instruction) bool {
+				val, ok := storeState[i]
+				if !ok {
+					return false
+				}
+				return val
+			},
+		}
+
+		blockKey := ocr2keepers2.BlockKey("testBlockKey")
+
+		outcome := ocr2keepers.AutomationOutcome{
+			Instructions: []instruction.Instruction{
+				ShouldCoordinateBlock,
+			},
+			Metadata: map[string]interface{}{
+				"coordinatedBlock": blockKey,
+			},
+		}
+
+		store.Set(ShouldCoordinateBlock)
+
+		var setBlock ocr2keepers2.BlockKey
+		blockSetter := &mockBlockSetter{
+			SetBlockFn: func(key ocr2keepers2.BlockKey) {
+				setBlock = key
+			},
+		}
+
+		hook := NewCoordinateBlockHook(store, blockSetter)
+
+		err := hook.RunHook(outcome)
+		assert.NoError(t, err)
+
+		assert.True(t, store.Has(DoCoordinateBlock))
+		assert.False(t, store.Has(ShouldCoordinateBlock))
+
+		assert.Equal(t, setBlock, blockKey)
+	})
+
+	t.Run("an error is returned when the metadata stores the wrong data type for coordinated block", func(t *testing.T) {
+		storeState := make(map[instruction.Instruction]bool)
+		store := &mockInstructionStore{
+			SetFn: func(i instruction.Instruction) {
+				storeState[i] = true
+			},
+			DeleteFn: func(i instruction.Instruction) {
+				delete(storeState, i)
+			},
+			HasFn: func(i instruction.Instruction) bool {
+				val, ok := storeState[i]
+				if !ok {
+					return false
+				}
+				return val
+			},
+		}
+
+		outcome := ocr2keepers.AutomationOutcome{
+			Instructions: []instruction.Instruction{
+				ShouldCoordinateBlock,
+			},
+			Metadata: map[string]interface{}{
+				"coordinatedBlock": "not a block",
+			},
+		}
+
+		store.Set(ShouldCoordinateBlock)
+
+		blockSetter := &mockBlockSetter{}
+
+		hook := NewCoordinateBlockHook(store, blockSetter)
+
+		err := hook.RunHook(outcome)
+		assert.Error(t, err)
+
+		assert.True(t, store.Has(DoCoordinateBlock))
+		assert.False(t, store.Has(ShouldCoordinateBlock))
+	})
+}

--- a/pkg/v3/hooks/prebuild/remove_from_staging.go
+++ b/pkg/v3/hooks/prebuild/remove_from_staging.go
@@ -10,7 +10,7 @@ type resultRemover interface {
 	Remove(...string)
 }
 
-func NewPrebuildHookRemoveFromStaging(remover resultRemover, logger *log.Logger) *RemoveFromStagingHook {
+func NewRemoveFromStaging(remover resultRemover, logger *log.Logger) *RemoveFromStagingHook {
 	return &RemoveFromStagingHook{remover: remover, logger: logger}
 }
 

--- a/pkg/v3/hooks/prebuild/remove_from_staging.go
+++ b/pkg/v3/hooks/prebuild/remove_from_staging.go
@@ -1,4 +1,4 @@
-package hooks
+package prebuild
 
 import (
 	"log"
@@ -10,16 +10,16 @@ type resultRemover interface {
 	Remove(...string)
 }
 
-func NewPrebuildHookRemoveFromStaging(remover resultRemover, logger *log.Logger) *PrebuildHookRemoveFromStaging {
-	return &PrebuildHookRemoveFromStaging{remover: remover, logger: logger}
+func NewPrebuildHookRemoveFromStaging(remover resultRemover, logger *log.Logger) *RemoveFromStagingHook {
+	return &RemoveFromStagingHook{remover: remover, logger: logger}
 }
 
-type PrebuildHookRemoveFromStaging struct {
+type RemoveFromStagingHook struct {
 	remover resultRemover
 	logger  *log.Logger
 }
 
-func (hook *PrebuildHookRemoveFromStaging) RunHook(outcome ocr2keepersv3.AutomationOutcome) error {
+func (hook *RemoveFromStagingHook) RunHook(outcome ocr2keepersv3.AutomationOutcome) error {
 	toRemove := make([]string, 0, len(outcome.Performable))
 
 	for _, result := range outcome.Performable {

--- a/pkg/v3/hooks/prebuild/remove_from_staging_test.go
+++ b/pkg/v3/hooks/prebuild/remove_from_staging_test.go
@@ -47,7 +47,7 @@ func TestRemoveFromStagingHook(t *testing.T) {
 
 			mr := new(mockRemover)
 
-			r := NewPrebuildHookRemoveFromStaging(mr, log.New(io.Discard, "", 0))
+			r := NewRemoveFromStaging(mr, log.New(io.Discard, "", 0))
 
 			assert.NoError(t, r.RunHook(ob))
 			assert.Equal(t, len(ob.Performable), len(mr.removed))

--- a/pkg/v3/hooks/prebuild/remove_from_staging_test.go
+++ b/pkg/v3/hooks/prebuild/remove_from_staging_test.go
@@ -1,16 +1,17 @@
-package hooks
+package prebuild
 
 import (
 	"io"
 	"log"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	ocr2keepers "github.com/smartcontractkit/ocr2keepers/pkg"
 	ocr2keepersv3 "github.com/smartcontractkit/ocr2keepers/pkg/v3"
-	"github.com/stretchr/testify/assert"
 )
 
-func TestPrebuildHookRemoveFromStaging(t *testing.T) {
+func TestRemoveFromStagingHook(t *testing.T) {
 	tests := []struct {
 		Name  string
 		Input []ocr2keepers.CheckResult

--- a/pkg/v3/instruction/instruction.go
+++ b/pkg/v3/instruction/instruction.go
@@ -1,0 +1,9 @@
+package instruction
+
+type Instruction string
+
+type InstructionStore interface {
+	Set(key Instruction)
+	Has(key Instruction) bool
+	Delete(key Instruction)
+}

--- a/pkg/v3/ocrtypes.go
+++ b/pkg/v3/ocrtypes.go
@@ -4,11 +4,12 @@ import (
 	"encoding/json"
 
 	ocr2keepers "github.com/smartcontractkit/ocr2keepers/pkg"
+	"github.com/smartcontractkit/ocr2keepers/pkg/v3/instruction"
 )
 
 // AutomationObservation models the proposed actionable decisions made by a single node
 type AutomationObservation struct {
-	Instructions []string
+	Instructions []instruction.Instruction
 	Metadata     map[string]interface{}
 	Performable  []ocr2keepers.CheckResult
 }
@@ -25,7 +26,7 @@ func DecodeAutomationObservation(data []byte) (AutomationObservation, error) {
 
 // AutomationOutcome represents decisions proposed by a single node based on observations.
 type AutomationOutcome struct {
-	Instructions []string
+	Instructions []instruction.Instruction
 	Metadata     map[string]interface{}
 	Performable  []ocr2keepers.CheckResult
 }

--- a/pkg/v3/ocrtypes_test.go
+++ b/pkg/v3/ocrtypes_test.go
@@ -7,12 +7,13 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	ocr2keepers "github.com/smartcontractkit/ocr2keepers/pkg"
+	"github.com/smartcontractkit/ocr2keepers/pkg/v3/instruction"
 )
 
 func TestAutomationObservation(t *testing.T) {
 	// set non-default values to test encoding/decoding
 	expected := AutomationObservation{
-		Instructions: []string{"instruction1", "instruction2"},
+		Instructions: []instruction.Instruction{"instruction1", "instruction2"},
 		Metadata:     map[string]interface{}{"key": "value"},
 		Performable: []ocr2keepers.CheckResult{
 			{
@@ -50,7 +51,7 @@ func TestAutomationObservation(t *testing.T) {
 func TestAutomationOutcome(t *testing.T) {
 	// set non-default values to test encoding/decoding
 	expected := AutomationOutcome{
-		Instructions: []string{"instruction1", "instruction2"},
+		Instructions: []instruction.Instruction{"instruction1", "instruction2"},
 		Metadata:     map[string]interface{}{"key": "value"},
 		Performable: []ocr2keepers.CheckResult{
 			{

--- a/pkg/v3/plugin/plugin.go
+++ b/pkg/v3/plugin/plugin.go
@@ -9,7 +9,8 @@ import (
 	ocr2keepersv3 "github.com/smartcontractkit/ocr2keepers/pkg/v3"
 	"github.com/smartcontractkit/ocr2keepers/pkg/v3/coordinator"
 	"github.com/smartcontractkit/ocr2keepers/pkg/v3/flows"
-	"github.com/smartcontractkit/ocr2keepers/pkg/v3/hooks"
+	"github.com/smartcontractkit/ocr2keepers/pkg/v3/hooks/build"
+	"github.com/smartcontractkit/ocr2keepers/pkg/v3/hooks/prebuild"
 	"github.com/smartcontractkit/ocr2keepers/pkg/v3/resultstore"
 	"github.com/smartcontractkit/ocr2keepers/pkg/v3/runner"
 	"github.com/smartcontractkit/ocr2keepers/pkg/v3/service"
@@ -60,10 +61,10 @@ func newPlugin[RI any](
 	plugin := &ocr3Plugin[RI]{
 		PrebuildHooks: []func(ocr2keepersv3.AutomationOutcome) error{
 			ltFlow.ProcessOutcome,
-			hooks.NewPrebuildHookRemoveFromStaging(rs, logger).RunHook,
+			prebuild.NewPrebuildHookRemoveFromStaging(rs, logger).RunHook,
 		},
 		BuildHooks: []func(*ocr2keepersv3.AutomationObservation) error{
-			hooks.NewBuildHookAddFromStaging(rs, logger).RunHook,
+			build.NewBuildHookAddFromStaging(rs, logger).RunHook,
 		},
 		ReportEncoder: encoder,
 		Coordinator:   coord,

--- a/pkg/v3/plugin/plugin.go
+++ b/pkg/v3/plugin/plugin.go
@@ -61,10 +61,10 @@ func newPlugin[RI any](
 	plugin := &ocr3Plugin[RI]{
 		PrebuildHooks: []func(ocr2keepersv3.AutomationOutcome) error{
 			ltFlow.ProcessOutcome,
-			prebuild.NewPrebuildHookRemoveFromStaging(rs, logger).RunHook,
+			prebuild.NewRemoveFromStaging(rs, logger).RunHook,
 		},
 		BuildHooks: []func(*ocr2keepersv3.AutomationObservation) error{
-			build.NewBuildHookAddFromStaging(rs, logger).RunHook,
+			build.NewAddFromStaging(rs, logger).RunHook,
 		},
 		ReportEncoder: encoder,
 		Coordinator:   coord,

--- a/pkg/v3/stores.go
+++ b/pkg/v3/stores.go
@@ -35,6 +35,7 @@ type MetadataStore interface {
 	Start() error
 	// Stop should stop watching for new block heights
 	Stop() error
+	GetBlockHistory() ocr2keepers.BlockHistory
 }
 
 // Notification is a struct that will be sent by the ResultStore upon certain events happening
@@ -107,6 +108,12 @@ func NewMetadataStore(ticker *tickers.BlockTicker) *metadataStore {
 		ticker: ticker,
 		stopCh: stopCh,
 	}
+}
+
+func (s *metadataStore) GetBlockHistory() ocr2keepers.BlockHistory {
+	s.m.RLock()
+	defer s.m.RUnlock()
+	return s.blockHistory
 }
 
 func (s *metadataStore) Set(identifiers []ocr2keepers.UpkeepIdentifier) error {


### PR DESCRIPTION
In this PR we're:

- Restructuring hooks into`prebuild` and `build` packages
- Moving the instruction store and instructions into their own package (we were running into import cycles in tests)
- Adding a new coordinate block prebuild hook that:
  -  Reads the instructions from the outcome, and if `ShouldCoordinateBlock` is present, adds `DoCoordinateBlock` to the instruction store
- Adding a new coordinate block build hook that:
  - reads the instruction store for the `ShouldCoordinateBlock` instruction, and if present, broadcasts the `ShouldCoordinateBlock` instruction on the observation
  - reads the instruction store for the `DoCoordinateBlock` instruction, and if present, adds the block history from the metadata store into the observation's metadata
 