### PR TITLE
Build Hook Dependencies

### DIFF
--- a/pkg/v3/hooks/build.go
+++ b/pkg/v3/hooks/build.go
@@ -6,16 +6,17 @@ import (
 	ocr2keepersv3 "github.com/smartcontractkit/ocr2keepers/pkg/v3"
 )
 
-func NewBuildHookAddFromStaging(logger *log.Logger) *BuildHookAddFromStaging {
-	return &BuildHookAddFromStaging{logger: logger}
+func NewBuildHookAddFromStaging(rStore ocr2keepersv3.ResultStore, logger *log.Logger) *BuildHookAddFromStaging {
+	return &BuildHookAddFromStaging{rStore: rStore, logger: logger}
 }
 
 type BuildHookAddFromStaging struct {
+	rStore ocr2keepersv3.ResultStore
 	logger *log.Logger
 }
 
-func (hook *BuildHookAddFromStaging) RunHook(obs *ocr2keepersv3.AutomationObservation, _ ocr2keepersv3.InstructionStore, _ ocr2keepersv3.MetadataStore, rStore ocr2keepersv3.ResultStore) error {
-	results, err := rStore.View()
+func (hook *BuildHookAddFromStaging) RunHook(obs *ocr2keepersv3.AutomationObservation) error {
+	results, err := hook.rStore.View()
 	if err != nil {
 		return err
 	}

--- a/pkg/v3/hooks/build_test.go
+++ b/pkg/v3/hooks/build_test.go
@@ -12,9 +12,9 @@ import (
 )
 
 func TestBuildHookAddFromStaging(t *testing.T) {
-	hook := NewBuildHookAddFromStaging(log.New(io.Discard, "", 0))
-	observation := &ocr2keepersv3.AutomationObservation{}
 	rs := resultstore.New(log.New(io.Discard, "", 0))
+	hook := NewBuildHookAddFromStaging(rs, log.New(io.Discard, "", 0))
+	observation := &ocr2keepersv3.AutomationObservation{}
 	expected := []ocr2keepers.CheckResult{
 		{Payload: ocr2keepers.UpkeepPayload{ID: "test1"}},
 		{Payload: ocr2keepers.UpkeepPayload{ID: "test2"}},
@@ -22,7 +22,7 @@ func TestBuildHookAddFromStaging(t *testing.T) {
 
 	rs.Add(expected...)
 
-	err := hook.RunHook(observation, nil, nil, rs)
+	err := hook.RunHook(observation)
 
 	assert.NoError(t, err, "no error from run hook")
 	assert.Len(t, observation.Performable, len(expected), "all check results should be in observation")

--- a/pkg/v3/plugin/ocr3.go
+++ b/pkg/v3/plugin/ocr3.go
@@ -26,16 +26,13 @@ type Coordinator interface {
 }
 
 type ocr3Plugin[RI any] struct {
-	PrebuildHooks     []func(ocr2keepersv3.AutomationOutcome) error
-	BuildHooks        []func(*ocr2keepersv3.AutomationObservation, ocr2keepersv3.InstructionStore, ocr2keepersv3.MetadataStore, ocr2keepersv3.ResultStore) error
-	InstructionSource ocr2keepersv3.InstructionStore
-	MetadataSource    ocr2keepersv3.MetadataStore
-	ResultSource      ocr2keepersv3.ResultStore
-	ReportEncoder     Encoder
-	Coordinator       Coordinator
-	Services          []service.Recoverable
-	Config            config.OffchainConfig
-	Logger            *log.Logger
+	PrebuildHooks []func(ocr2keepersv3.AutomationOutcome) error
+	BuildHooks    []func(*ocr2keepersv3.AutomationObservation) error
+	ReportEncoder Encoder
+	Coordinator   Coordinator
+	Services      []service.Recoverable
+	Config        config.OffchainConfig
+	Logger        *log.Logger
 }
 
 func (plugin *ocr3Plugin[RI]) Query(ctx context.Context, outctx ocr3types.OutcomeContext) (types.Query, error) {
@@ -67,7 +64,7 @@ func (plugin *ocr3Plugin[RI]) Observation(ctx context.Context, outcome ocr3types
 	// Execute build hooks
 	plugin.Logger.Printf("running build hooks")
 	for _, hook := range plugin.BuildHooks {
-		err := hook(&observation, plugin.InstructionSource, plugin.MetadataSource, plugin.ResultSource)
+		err := hook(&observation)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/v3/plugin/ocr3_test.go
+++ b/pkg/v3/plugin/ocr3_test.go
@@ -35,7 +35,7 @@ func TestObservation(t *testing.T) {
 	plugin.PrebuildHooks = append(plugin.PrebuildHooks, mockPrebuildHook)
 
 	// Define a mock build hook function for testing build hooks
-	mockBuildHook := func(observation *ocr2keepersv3.AutomationObservation, instructionStore ocr2keepersv3.InstructionStore, samplingStore ocr2keepersv3.MetadataStore, resultStore ocr2keepersv3.ResultStore) error {
+	mockBuildHook := func(observation *ocr2keepersv3.AutomationObservation) error {
 		assert.Equal(t, 0, len(observation.Instructions))
 		return nil
 	}

--- a/pkg/v3/plugin/plugin.go
+++ b/pkg/v3/plugin/plugin.go
@@ -62,10 +62,9 @@ func newPlugin[RI any](
 			ltFlow.ProcessOutcome,
 			hooks.NewPrebuildHookRemoveFromStaging(rs, logger).RunHook,
 		},
-		BuildHooks: []func(*ocr2keepersv3.AutomationObservation, ocr2keepersv3.InstructionStore, ocr2keepersv3.MetadataStore, ocr2keepersv3.ResultStore) error{
-			hooks.NewBuildHookAddFromStaging(logger).RunHook,
+		BuildHooks: []func(*ocr2keepersv3.AutomationObservation) error{
+			hooks.NewBuildHookAddFromStaging(rs, logger).RunHook,
 		},
-		ResultSource:  rs,
 		ReportEncoder: encoder,
 		Coordinator:   coord,
 		Services:      recoverSvcs,


### PR DESCRIPTION
Build hooks depend on various stores to work and currently they are being passed to each build hook. This convolutes the concept of what the build hooks are for in that that should be writers to the Observation.

Instead, the stores can be provided to each build hook which will simplify the hook interface, make the build hook concept more extendable, and make the intent of the hooks more explicit.