### PR TITLE
Outcome History Ring Buffer

### DIFF
--- a/pkg/v3/hooks/prebuild/coordinate_block_test.go
+++ b/pkg/v3/hooks/prebuild/coordinate_block_test.go
@@ -49,10 +49,12 @@ func TestNewCoordinateBlockHook(t *testing.T) {
 		}
 
 		outcome := ocr2keepers.AutomationOutcome{
+			BasicOutcome: ocr2keepers.BasicOutcome{
+				Metadata: map[ocr2keepers.OutcomeMetadataKey]interface{}{},
+			},
 			Instructions: []instructions.Instruction{
 				instructions.ShouldCoordinateBlock,
 			},
-			Metadata: map[ocr2keepers.OutcomeMetadataKey]interface{}{},
 		}
 
 		iStore.Set(instructions.ShouldCoordinateBlock)
@@ -92,11 +94,13 @@ func TestNewCoordinateBlockHook(t *testing.T) {
 		blockKey := ocr2keepers2.BlockKey("testBlockKey")
 
 		outcome := ocr2keepers.AutomationOutcome{
+			BasicOutcome: ocr2keepers.BasicOutcome{
+				Metadata: map[ocr2keepers.OutcomeMetadataKey]interface{}{
+					ocr2keepers.CoordinatedBlockOutcomeKey: blockKey,
+				},
+			},
 			Instructions: []instructions.Instruction{
 				instructions.DoCoordinateBlock,
-			},
-			Metadata: map[ocr2keepers.OutcomeMetadataKey]interface{}{
-				ocr2keepers.CoordinatedBlockOutcomeKey: blockKey,
 			},
 		}
 
@@ -135,11 +139,13 @@ func TestNewCoordinateBlockHook(t *testing.T) {
 		}
 
 		outcome := ocr2keepers.AutomationOutcome{
+			BasicOutcome: ocr2keepers.BasicOutcome{
+				Metadata: map[ocr2keepers.OutcomeMetadataKey]interface{}{
+					ocr2keepers.CoordinatedBlockOutcomeKey: "not a block",
+				},
+			},
 			Instructions: []instructions.Instruction{
 				instructions.ShouldCoordinateBlock,
-			},
-			Metadata: map[ocr2keepers.OutcomeMetadataKey]interface{}{
-				ocr2keepers.CoordinatedBlockOutcomeKey: "not a block",
 			},
 		}
 

--- a/pkg/v3/hooks/prebuild/remove_from_staging_test.go
+++ b/pkg/v3/hooks/prebuild/remove_from_staging_test.go
@@ -42,7 +42,9 @@ func TestRemoveFromStagingHook(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
 			ob := ocr2keepersv3.AutomationOutcome{
-				Performable: test.Input,
+				BasicOutcome: ocr2keepersv3.BasicOutcome{
+					Performable: test.Input,
+				},
 			}
 
 			mr := new(mockRemover)

--- a/pkg/v3/ocrtypes.go
+++ b/pkg/v3/ocrtypes.go
@@ -34,9 +34,15 @@ func DecodeAutomationObservation(data []byte) (AutomationObservation, error) {
 
 // AutomationOutcome represents decisions proposed by a single node based on observations.
 type AutomationOutcome struct {
+	BasicOutcome
 	Instructions []instructions.Instruction
-	Metadata     map[OutcomeMetadataKey]interface{}
-	Performable  []ocr2keepers.CheckResult
+	History      []BasicOutcome
+	LatestIdx    int
+}
+
+type BasicOutcome struct {
+	Metadata    map[OutcomeMetadataKey]interface{}
+	Performable []ocr2keepers.CheckResult
 }
 
 func (outcome AutomationOutcome) Encode() ([]byte, error) {

--- a/pkg/v3/ocrtypes.go
+++ b/pkg/v3/ocrtypes.go
@@ -37,7 +37,7 @@ type AutomationOutcome struct {
 	BasicOutcome
 	Instructions []instructions.Instruction
 	History      []BasicOutcome
-	LatestIdx    int
+	NextIdx      int
 }
 
 type BasicOutcome struct {

--- a/pkg/v3/ocrtypes_test.go
+++ b/pkg/v3/ocrtypes_test.go
@@ -51,27 +51,29 @@ func TestAutomationObservation(t *testing.T) {
 func TestAutomationOutcome(t *testing.T) {
 	// set non-default values to test encoding/decoding
 	expected := AutomationOutcome{
-		Instructions: []instructions.Instruction{"instruction1", "instruction2"},
-		Metadata:     map[OutcomeMetadataKey]interface{}{"key": "value"},
-		Performable: []ocr2keepers.CheckResult{
-			{
-				Payload: ocr2keepers.UpkeepPayload{
-					ID: "abc",
-					Upkeep: ocr2keepers.ConfiguredUpkeep{
-						ID:   []byte("111"),
-						Type: 1,
+		BasicOutcome: BasicOutcome{
+			Metadata: map[OutcomeMetadataKey]interface{}{"key": "value"},
+			Performable: []ocr2keepers.CheckResult{
+				{
+					Payload: ocr2keepers.UpkeepPayload{
+						ID: "abc",
+						Upkeep: ocr2keepers.ConfiguredUpkeep{
+							ID:   []byte("111"),
+							Type: 1,
+						},
+						CheckData: []byte("check data"),
+						Trigger: ocr2keepers.Trigger{
+							BlockNumber: 4,
+							BlockHash:   "hash",
+						},
 					},
-					CheckData: []byte("check data"),
-					Trigger: ocr2keepers.Trigger{
-						BlockNumber: 4,
-						BlockHash:   "hash",
-					},
+					Retryable:   true,
+					Eligible:    true,
+					PerformData: []byte("testing"),
 				},
-				Retryable:   true,
-				Eligible:    true,
-				PerformData: []byte("testing"),
 			},
 		},
+		Instructions: []instructions.Instruction{"instruction1", "instruction2"},
 	}
 
 	jsonData, _ := json.Marshal(expected)

--- a/pkg/v3/plugin/history.go
+++ b/pkg/v3/plugin/history.go
@@ -1,0 +1,42 @@
+package plugin
+
+import ocr2keepersv3 "github.com/smartcontractkit/ocr2keepers/pkg/v3"
+
+func UpdateHistory(previous *ocr2keepersv3.AutomationOutcome, next *ocr2keepersv3.AutomationOutcome, maxLength int) {
+	var (
+		historyIdx int
+		history    []ocr2keepersv3.BasicOutcome
+	)
+
+	if previous != nil {
+		historyIdx = previous.NextIdx
+
+		if len(previous.History) < maxLength {
+			history = make([]ocr2keepersv3.BasicOutcome, len(previous.History))
+			copy(history, previous.History[:len(previous.History)])
+		} else {
+			history = make([]ocr2keepersv3.BasicOutcome, maxLength)
+			copy(history, previous.History[:maxLength])
+		}
+
+		// apply the basic outcome to the history
+		if len(history) < maxLength {
+			// if the history is still less than the limit the new value can be
+			// safely appended
+			history = append(history, previous.BasicOutcome)
+		} else {
+			// if the history is at the limit the latest value reset the value at
+			// the latest index. this creates a ring buffer of history values
+			history[historyIdx] = previous.BasicOutcome
+		}
+
+		// advance the latest by 1
+		historyIdx++
+		if historyIdx >= maxLength {
+			historyIdx = 0
+		}
+	}
+
+	next.History = history
+	next.NextIdx = historyIdx
+}

--- a/pkg/v3/plugin/history_test.go
+++ b/pkg/v3/plugin/history_test.go
@@ -1,0 +1,160 @@
+package plugin
+
+import (
+	"testing"
+
+	ocr2keepers "github.com/smartcontractkit/ocr2keepers/pkg"
+	ocr2keepersv3 "github.com/smartcontractkit/ocr2keepers/pkg/v3"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUpdateHistory(t *testing.T) {
+	t.Run("nil previous outcome", func(t *testing.T) {
+		next := ocr2keepersv3.AutomationOutcome{
+			BasicOutcome: ocr2keepersv3.BasicOutcome{
+				Metadata: map[ocr2keepersv3.OutcomeMetadataKey]interface{}{
+					ocr2keepersv3.CoordinatedBlockOutcomeKey: nil,
+				},
+			},
+		}
+
+		UpdateHistory(nil, &next, 10)
+
+		assert.Equal(t, 0, len(next.History), "history should be unchanged")
+		assert.Equal(t, 0, next.NextIdx, "history should be 0, the first index to put the next history item")
+	})
+
+	t.Run("empty history in previous outcome", func(t *testing.T) {
+		previous := ocr2keepersv3.AutomationOutcome{
+			BasicOutcome: ocr2keepersv3.BasicOutcome{
+				Metadata: map[ocr2keepersv3.OutcomeMetadataKey]interface{}{
+					ocr2keepersv3.CoordinatedBlockOutcomeKey: nil,
+				},
+			},
+		}
+
+		next := ocr2keepersv3.AutomationOutcome{
+			BasicOutcome: ocr2keepersv3.BasicOutcome{
+				Metadata: map[ocr2keepersv3.OutcomeMetadataKey]interface{}{
+					ocr2keepersv3.CoordinatedBlockOutcomeKey: nil,
+				},
+			},
+		}
+
+		assert.Equal(t, 0, len(next.History), "history should be empty before the update")
+
+		UpdateHistory(&previous, &next, 10)
+
+		assert.Equal(t, 1, len(next.History), "history should be updated to 1")
+		assert.Equal(t, 1, next.NextIdx, "history should be 1, the next index to put the next history item")
+	})
+
+	t.Run("history of length 1 in previous outcome", func(t *testing.T) {
+		previous := ocr2keepersv3.AutomationOutcome{
+			BasicOutcome: ocr2keepersv3.BasicOutcome{
+				Metadata: map[ocr2keepersv3.OutcomeMetadataKey]interface{}{
+					ocr2keepersv3.CoordinatedBlockOutcomeKey: ocr2keepers.BlockKey("2"),
+				},
+			},
+			History: []ocr2keepersv3.BasicOutcome{
+				{
+					Metadata: map[ocr2keepersv3.OutcomeMetadataKey]interface{}{
+						ocr2keepersv3.CoordinatedBlockOutcomeKey: ocr2keepers.BlockKey("1"),
+					},
+				},
+			},
+			NextIdx: 1,
+		}
+
+		next := ocr2keepersv3.AutomationOutcome{
+			BasicOutcome: ocr2keepersv3.BasicOutcome{
+				Metadata: map[ocr2keepersv3.OutcomeMetadataKey]interface{}{
+					ocr2keepersv3.CoordinatedBlockOutcomeKey: nil,
+				},
+			},
+		}
+
+		expected := []ocr2keepersv3.BasicOutcome{
+			{
+				Metadata: map[ocr2keepersv3.OutcomeMetadataKey]interface{}{
+					ocr2keepersv3.CoordinatedBlockOutcomeKey: ocr2keepers.BlockKey("1"),
+				},
+			},
+			{
+				Metadata: map[ocr2keepersv3.OutcomeMetadataKey]interface{}{
+					ocr2keepersv3.CoordinatedBlockOutcomeKey: ocr2keepers.BlockKey("2"),
+				},
+			},
+		}
+
+		assert.Equal(t, 0, len(next.History), "history should be empty before the update")
+
+		UpdateHistory(&previous, &next, 10)
+
+		assert.Equal(t, 2, len(next.History), "history should be updated to 2")
+		assert.Equal(t, 2, next.NextIdx, "history should be 2, the next index to put the next history item")
+		assert.Equal(t, expected, next.History, "history items should match expected order")
+	})
+
+	t.Run("history of max length in previous outcome", func(t *testing.T) {
+		previous := ocr2keepersv3.AutomationOutcome{
+			BasicOutcome: ocr2keepersv3.BasicOutcome{
+				Metadata: map[ocr2keepersv3.OutcomeMetadataKey]interface{}{
+					ocr2keepersv3.CoordinatedBlockOutcomeKey: ocr2keepers.BlockKey("4"),
+				},
+			},
+			History: []ocr2keepersv3.BasicOutcome{
+				{
+					Metadata: map[ocr2keepersv3.OutcomeMetadataKey]interface{}{
+						ocr2keepersv3.CoordinatedBlockOutcomeKey: ocr2keepers.BlockKey("1"),
+					},
+				},
+				{
+					Metadata: map[ocr2keepersv3.OutcomeMetadataKey]interface{}{
+						ocr2keepersv3.CoordinatedBlockOutcomeKey: ocr2keepers.BlockKey("2"),
+					},
+				},
+				{
+					Metadata: map[ocr2keepersv3.OutcomeMetadataKey]interface{}{
+						ocr2keepersv3.CoordinatedBlockOutcomeKey: ocr2keepers.BlockKey("3"),
+					},
+				},
+			},
+			NextIdx: 0,
+		}
+
+		next := ocr2keepersv3.AutomationOutcome{
+			BasicOutcome: ocr2keepersv3.BasicOutcome{
+				Metadata: map[ocr2keepersv3.OutcomeMetadataKey]interface{}{
+					ocr2keepersv3.CoordinatedBlockOutcomeKey: nil,
+				},
+			},
+		}
+
+		expected := []ocr2keepersv3.BasicOutcome{
+			{
+				Metadata: map[ocr2keepersv3.OutcomeMetadataKey]interface{}{
+					ocr2keepersv3.CoordinatedBlockOutcomeKey: ocr2keepers.BlockKey("4"),
+				},
+			},
+			{
+				Metadata: map[ocr2keepersv3.OutcomeMetadataKey]interface{}{
+					ocr2keepersv3.CoordinatedBlockOutcomeKey: ocr2keepers.BlockKey("2"),
+				},
+			},
+			{
+				Metadata: map[ocr2keepersv3.OutcomeMetadataKey]interface{}{
+					ocr2keepersv3.CoordinatedBlockOutcomeKey: ocr2keepers.BlockKey("3"),
+				},
+			},
+		}
+
+		assert.Equal(t, 0, len(next.History), "history should be empty before the update")
+
+		UpdateHistory(&previous, &next, 3)
+
+		assert.Equal(t, 3, len(next.History), "history should be maximum length")
+		assert.Equal(t, 1, next.NextIdx, "history should be 1, the next index to put the next history item")
+		assert.Equal(t, expected, next.History, "history items should match expected order")
+	})
+}

--- a/pkg/v3/plugin/ocr3.go
+++ b/pkg/v3/plugin/ocr3.go
@@ -108,28 +108,6 @@ func (plugin *ocr3Plugin) Outcome(outctx ocr3types.OutcomeContext, query types.Q
 		c.add(observation)
 	}
 
-	var latestIdx int
-	var history []ocr2keepersv3.BasicOutcome
-
-	if outctx.SeqNr != 1 {
-		prev, err := ocr2keepersv3.DecodeAutomationOutcome(outctx.PreviousOutcome)
-		if err != nil {
-			return nil, err
-		}
-
-		// TODO: validate outcome (even though it is a signed outcome)
-
-		latestIdx = prev.LatestIdx
-
-		if len(prev.History) < OutcomeHistoryLimit {
-			history = make([]ocr2keepersv3.BasicOutcome, len(prev.History))
-			copy(history, prev.History[:len(prev.History)])
-		} else {
-			history = make([]ocr2keepersv3.BasicOutcome, OutcomeHistoryLimit)
-			copy(history, prev.History[:OutcomeHistoryLimit])
-		}
-	}
-
 	outcome := ocr2keepersv3.AutomationOutcome{
 		BasicOutcome: ocr2keepersv3.BasicOutcome{
 			Metadata: make(map[ocr2keepersv3.OutcomeMetadataKey]interface{}),
@@ -139,24 +117,20 @@ func (plugin *ocr3Plugin) Outcome(outctx ocr3types.OutcomeContext, query types.Q
 	p.set(&outcome)
 	c.set(&outcome)
 
-	// advance the latest by 1 and apply the basic outcome to the history
-	latestIdx++
-	if latestIdx >= OutcomeHistoryLimit {
-		latestIdx = 0
+	var previous *ocr2keepersv3.AutomationOutcome
+	if outctx.SeqNr != 1 {
+		p, err := ocr2keepersv3.DecodeAutomationOutcome(outctx.PreviousOutcome)
+		if err != nil {
+			return nil, err
+		}
+
+		// TODO: validate outcome (even though it is a signed outcome)
+
+		previous = &p
 	}
 
-	if len(history) < OutcomeHistoryLimit {
-		// if the history is still less than the limit the new value can be
-		// safely appended
-		history = append(history, outcome.BasicOutcome)
-	} else {
-		// if the history is at the limit the latest value reset the value at
-		// the latest index. this creates a ring buffer of history values
-		history[latestIdx] = outcome.BasicOutcome
-	}
-
-	outcome.History = history
-	outcome.LatestIdx = latestIdx
+	// set the latest value in the history
+	UpdateHistory(previous, &outcome, OutcomeHistoryLimit)
 
 	plugin.Logger.Printf("returning outcome with %d results", len(outcome.Performable))
 


### PR DESCRIPTION
Block coordination happens independently of other data coordination, but is a required value for other processes. To correctly be able to merge coordinated blocks and coordinated recoverable ids, outcome history is required. This can either be local state or we can use the outcome to store previous coordinated values.

This commit introduces a ring buffer of outcome history that is maintained collectively by all nodes. This allows all nodes to coordinate on various bits of data as well as recent history.