### PR TITLE
Connect recovery flow components

### DIFF
--- a/pkg/v3/flows/logtrigger.go
+++ b/pkg/v3/flows/logtrigger.go
@@ -105,16 +105,16 @@ func NewLogTriggerEligibility(
 	// each flow can add preprocessors to this provided slice
 	preprocessors := []ocr2keepersv3.PreProcessor[ocr2keepers.UpkeepPayload]{coord}
 
+	// the recovery proposal flow is for nodes to surface payloads that should
+	// be recovered. these values are passed to the network and the network
+	// votes on the proposed values
+	svc0, recoveryProposer := newRecoveryProposalFlow(preprocessors, mStore, rp, recoveryInterval, logger, recoverConfigs...)
+
 	// the final recovery flow takes recoverable payloads merged with the latest
 	// blocks and runs the pipeline for them. these values to run are derived
 	// from node coordination and it can be assumed that all values should be
 	// run.
-	svc0, recoverer := newFinalRecoveryFlow(preprocessors, rStore, runner, recoveryInterval, logger)
-
-	// the recovery proposal flow is for nodes to surface payloads that should
-	// be recovered. these values are passed to the network and the network
-	// votes on the proposed values
-	svc1, recoveryProposer := newRecoveryProposalFlow(preprocessors, mStore, rp, recoveryInterval, logger, recoverConfigs...)
+	svc1, recoverer := newFinalRecoveryFlow(preprocessors, rStore, runner, recoveryProposer, recoveryInterval, logger)
 
 	// the retry flow is for payloads where the block number is still within
 	// range of RPC data. this is a short range retry and failures here get

--- a/pkg/v3/flows/recovery_test.go
+++ b/pkg/v3/flows/recovery_test.go
@@ -20,15 +20,15 @@ import (
 )
 
 func TestRecoveryFlow(t *testing.T) {
-
 	runner := &mockedRunner{eligibleAfter: 0}
 	rStore := new(mocks.MockResultStore)
 	coord := new(mockedPreprocessor)
+	rtyr := new(mocks.MockRetryer)
 	preprocessors := []ocr2keepersv3.PreProcessor[ocr2keepers.UpkeepPayload]{coord}
 
 	rStore.On("Add", mock.Anything).Times(1)
 
-	svc, recoverer := newFinalRecoveryFlow(preprocessors, rStore, runner, 20*time.Millisecond, log.New(io.Discard, "", 0))
+	svc, recoverer := newFinalRecoveryFlow(preprocessors, rStore, runner, rtyr, 20*time.Millisecond, log.New(io.Discard, "", 0))
 
 	var wg sync.WaitGroup
 	wg.Add(1)

--- a/pkg/v3/postprocessors/retry.go
+++ b/pkg/v3/postprocessors/retry.go
@@ -40,7 +40,7 @@ func (p *retryPostProcessor) attemptRetry(res ocr2keepers.CheckResult) error {
 	}
 
 	if err == nil || errors.Is(err, tickers.ErrSendDurationExceeded) {
-		if err := p.recoverer.Retry(res); err != nil {
+		if err = p.recoverer.Retry(res); err != nil {
 			return err
 		}
 	}

--- a/pkg/v3/postprocessors/retry_test.go
+++ b/pkg/v3/postprocessors/retry_test.go
@@ -40,7 +40,7 @@ func TestRetryPostProcessor_PostProcess(t *testing.T) {
 		recoverer.AssertExpectations(t)
 	})
 
-	t.Run("retry error; bump to recoverer", func(t *testing.T) {
+	t.Run("retry error bump to recoverer", func(t *testing.T) {
 		// Create a mock retryer with error
 		retryer := new(mockRetryer)
 		recoverer := new(mockRetryer)
@@ -69,7 +69,7 @@ func TestRetryPostProcessor_PostProcess(t *testing.T) {
 		retryer.AssertExpectations(t)
 		recoverer.AssertExpectations(t)
 	})
-	t.Run("unexpected retry error; early exit", func(t *testing.T) {
+	t.Run("unexpected retry error early exit", func(t *testing.T) {
 		// Create a mock retryer with error
 		retryer := new(mockRetryer)
 		recoverer := new(mockRetryer)


### PR DESCRIPTION
Items in the final recovery flow with coordinated block can still fail and end up recoverable again. By connecting the final recovery with the recovery proposal flow, recoverable items can be re-introduced to the recovery proposal process again and not need to rely as much on the recoverable provider.