### PR TITLE
trigger id is generated from core repo, clean it up from plugin

### DIFF
--- a/pkg/basetypes.go
+++ b/pkg/basetypes.go
@@ -1,13 +1,10 @@
 package ocr2keepers
 
 import (
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"math/big"
 	"strings"
-
-	"github.com/ethereum/go-ethereum/crypto"
 )
 
 type UpkeepIdentifier []byte
@@ -205,7 +202,6 @@ func NewUpkeepPayload(uid *big.Int, tp int, block BlockKey, trigger Trigger, che
 		Trigger:    trigger,
 		CheckData:  checkData,
 	}
-	p.ID = p.GenerateID()
 	return p
 }
 
@@ -219,12 +215,6 @@ func ValidateUpkeepPayload(p UpkeepPayload) error {
 	}
 
 	return ValidateTrigger(p.Trigger)
-}
-
-func (p UpkeepPayload) GenerateID() string {
-	id := fmt.Sprintf("%s:%s", p.Upkeep.ID, p.Trigger)
-	idh := crypto.Keccak256([]byte(id))
-	return hex.EncodeToString(idh[:])
 }
 
 type Trigger struct {

--- a/pkg/basetypes_test.go
+++ b/pkg/basetypes_test.go
@@ -2,25 +2,10 @@ package ocr2keepers
 
 import (
 	"encoding/json"
-	"math/big"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
-
-func TestUpkeepPayload_GenerateID(t *testing.T) {
-	payload := NewUpkeepPayload(big.NewInt(111), 1, BlockKey("4"), Trigger{
-		BlockNumber: 11,
-		BlockHash:   "0x11111",
-		Extension:   "extension111",
-	}, []byte("check-data-111"))
-	assert.Equal(t, "0a73a5fd0fc265416da897fa9d08509c336c847f80236389426ef0b95506912b", payload.ID)
-
-	t.Run("empty payload id", func(t *testing.T) {
-		payload = UpkeepPayload{}
-		assert.Equal(t, "20c9c9e789a8e576ba9d58b1324869aefcd92545f80a5ee3834ac29b2531a8aa", payload.GenerateID())
-	})
-}
 
 func TestTriggerUnmarshal(t *testing.T) {
 	input := Trigger{


### PR DESCRIPTION
This is a cleanup PR. we have upkeep trigger ID generation logic in the core [repo](https://github.com/smartcontractkit/chainlink/blob/c272befd714d827c890582d74df838345ed1caa7/core/services/ocr2/plugins/ocr2keeper/evm21/upkeep_info.go#L52), this payload will be passed to plugin, hence not needing the same logic in plugin. 

I could be way off, please comment in PR. 