### PR TITLE
Add WorkID to structs

### DIFF
--- a/cmd/simv3/simulators/registry_test.go
+++ b/cmd/simv3/simulators/registry_test.go
@@ -63,7 +63,9 @@ func TestCheckUpkeep(t *testing.T) {
 		},
 		Trigger: ocr2keepers.NewTrigger(8, "0x123", "conditional"),
 	}
-	payload1.ID = payload1.GenerateID()
+
+	// generateID was deprecated; find new way to create id
+	// payload1.ID = payload1.GenerateID()
 
 	res, err := contract.CheckUpkeeps(context.Background(), payload1)
 	assert.NoError(t, err)
@@ -81,7 +83,9 @@ func TestCheckUpkeep(t *testing.T) {
 		},
 		Trigger: ocr2keepers.NewTrigger(11, "0x123", "conditional"),
 	}
-	payload2.ID = payload2.GenerateID()
+
+	// generateID was deprecated; find new way to create id
+	// payload2.ID = payload2.GenerateID()
 
 	res, err = contract.CheckUpkeeps(context.Background(), payload2)
 	assert.NoError(t, err)

--- a/pkg/basetypes.go
+++ b/pkg/basetypes.go
@@ -1,13 +1,9 @@
 package ocr2keepers
 
 import (
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"math/big"
 	"strings"
-
-	"github.com/ethereum/go-ethereum/crypto"
 )
 
 type UpkeepIdentifier []byte
@@ -197,20 +193,6 @@ type UpkeepPayload struct {
 	Trigger Trigger
 }
 
-func NewUpkeepPayload(uid *big.Int, tp int, block BlockKey, trigger Trigger, checkData []byte) UpkeepPayload {
-	p := UpkeepPayload{
-		Upkeep: ConfiguredUpkeep{
-			ID:     UpkeepIdentifier(uid.Bytes()),
-			Type:   tp,
-			Config: struct{}{}, // empty struct by default
-		},
-		Trigger:   trigger,
-		CheckData: checkData,
-	}
-	p.ID = p.GenerateID()
-	return p
-}
-
 func ValidateUpkeepPayload(p UpkeepPayload) error {
 	if len(p.ID) == 0 {
 		return fmt.Errorf("upkeep payload id cannot be empty")
@@ -221,12 +203,6 @@ func ValidateUpkeepPayload(p UpkeepPayload) error {
 	}
 
 	return ValidateTrigger(p.Trigger)
-}
-
-func (p UpkeepPayload) GenerateID() string {
-	id := fmt.Sprintf("%s:%s", p.Upkeep.ID, p.Trigger)
-	idh := crypto.Keccak256([]byte(id))
-	return hex.EncodeToString(idh[:])
 }
 
 type Trigger struct {

--- a/pkg/basetypes.go
+++ b/pkg/basetypes.go
@@ -59,8 +59,10 @@ type TransmitEvent struct {
 	Confirmations int64
 	// TransactionHash is the hash for the transaction where the event originated
 	TransactionHash string
-	// ID uniquely identifies the upkeep/trigger that created this perform log
+	// ID uniquely identifies unit of work attempt that created this perform log
 	ID string
+	// WorkID uniquely identifies the unit of work for the specified upkeep
+	WorkID string
 	// UpkeepID uniquely identifies the upkeep in the registry
 	UpkeepID UpkeepIdentifier
 	// CheckBlock is the block value that the upkeep was originally checked at
@@ -182,12 +184,13 @@ func ValidateConfiguredUpkeep(u ConfiguredUpkeep) error {
 }
 
 type UpkeepPayload struct {
-	// ID uniquely identifies the upkeep payload
+	// ID uniquely identifies the upkeep payload and tracks attempts for the
+	// unit of work
 	ID string
+	// WorkID uniquely identifies the unit of work for the specified upkeep
+	WorkID string
 	// Upkeep is all the information that identifies the upkeep
 	Upkeep ConfiguredUpkeep
-	// CheckBlock: Deprecated
-	CheckBlock BlockKey
 	// CheckData is the data used to check the upkeep
 	CheckData []byte
 	// Trigger is the event that triggered the upkeep to be checked
@@ -201,9 +204,8 @@ func NewUpkeepPayload(uid *big.Int, tp int, block BlockKey, trigger Trigger, che
 			Type:   tp,
 			Config: struct{}{}, // empty struct by default
 		},
-		CheckBlock: block,
-		Trigger:    trigger,
-		CheckData:  checkData,
+		Trigger:   trigger,
+		CheckData: checkData,
 	}
 	p.ID = p.GenerateID()
 	return p
@@ -308,6 +310,8 @@ type CoordinatedProposal struct {
 type ReportedUpkeep struct {
 	// ID uniquely identifies the upkeep in the report
 	ID string
+	// WorkID uniquely identifies the unit of work for the specified upkeep
+	WorkID string
 	// UpkeepID is the value that identifies a configured upkeep
 	UpkeepID UpkeepIdentifier
 	// Trigger data for the upkeep

--- a/pkg/basetypes_test.go
+++ b/pkg/basetypes_test.go
@@ -2,25 +2,10 @@ package ocr2keepers
 
 import (
 	"encoding/json"
-	"math/big"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
-
-func TestUpkeepPayload_GenerateID(t *testing.T) {
-	payload := NewUpkeepPayload(big.NewInt(111), 1, BlockKey("4"), Trigger{
-		BlockNumber: 11,
-		BlockHash:   "0x11111",
-		Extension:   "extension111",
-	}, []byte("check-data-111"))
-	assert.Equal(t, "0a73a5fd0fc265416da897fa9d08509c336c847f80236389426ef0b95506912b", payload.ID)
-
-	t.Run("empty payload id", func(t *testing.T) {
-		payload = UpkeepPayload{}
-		assert.Equal(t, "20c9c9e789a8e576ba9d58b1324869aefcd92545f80a5ee3834ac29b2531a8aa", payload.GenerateID())
-	})
-}
 
 func TestTriggerUnmarshal(t *testing.T) {
 	input := Trigger{

--- a/pkg/v3/coordinator/conditional_report_coordinator_test.go
+++ b/pkg/v3/coordinator/conditional_report_coordinator_test.go
@@ -146,6 +146,7 @@ func TestConditionalReportCoordinator_isPending(t *testing.T) {
 		assert.NotNil(t, coordinator)
 
 		pending := coordinator.isPending(ocr2keepers.UpkeepPayload{
+			WorkID: "123",
 			Upkeep: ocr2keepers.ConfiguredUpkeep{
 				ID: []byte("123"),
 			},
@@ -170,6 +171,7 @@ func TestConditionalReportCoordinator_isPending(t *testing.T) {
 		}, config.DefaultCacheExpiration)
 
 		pending := coordinator.isPending(ocr2keepers.UpkeepPayload{
+			WorkID: "123",
 			Upkeep: ocr2keepers.ConfiguredUpkeep{
 				ID: []byte("123"),
 			},
@@ -224,6 +226,7 @@ func TestConditionalReportCoordinator_isPending(t *testing.T) {
 		}, config.DefaultCacheExpiration)
 
 		pending := coordinator.isPending(ocr2keepers.UpkeepPayload{
+			WorkID: "123",
 			Upkeep: ocr2keepers.ConfiguredUpkeep{
 				ID: []byte("123"),
 			},
@@ -484,6 +487,7 @@ func TestConditionalReportCoordinator_Accept(t *testing.T) {
 
 		err := coordinator.Accept(ocr2keepers.ReportedUpkeep{
 			ID:       "123",
+			WorkID:   "10",
 			UpkeepID: ocr2keepers.UpkeepIdentifier("10"),
 			Trigger: ocr2keepers.Trigger{
 				BlockNumber: 567,
@@ -518,12 +522,12 @@ func TestConditionalReportCoordinator_IsTransmissionConfirmed(t *testing.T) {
 		assert.NotNil(t, coordinator)
 
 		confirmed := coordinator.IsTransmissionConfirmed(ocr2keepers.UpkeepPayload{
-			ID: "123",
+			ID:     "123",
+			WorkID: "4",
 			Upkeep: ocr2keepers.ConfiguredUpkeep{
 				ID:   ocr2keepers.UpkeepIdentifier("4"),
 				Type: 1,
 			},
-			CheckBlock: "500",
 			Trigger: ocr2keepers.Trigger{
 				BlockNumber: 501,
 			},
@@ -547,12 +551,12 @@ func TestConditionalReportCoordinator_IsTransmissionConfirmed(t *testing.T) {
 		coordinator.activeKeys.Set("4", true, config.DefaultCacheExpiration)
 
 		confirmed := coordinator.IsTransmissionConfirmed(ocr2keepers.UpkeepPayload{
-			ID: "123",
+			ID:     "123",
+			WorkID: "4",
 			Upkeep: ocr2keepers.ConfiguredUpkeep{
 				ID:   ocr2keepers.UpkeepIdentifier("4"),
 				Type: 1,
 			},
-			CheckBlock: "500",
 			Trigger: ocr2keepers.Trigger{
 				BlockNumber: 501,
 			},
@@ -585,6 +589,7 @@ func TestConditionalReportCoordinator_PreProcess(t *testing.T) {
 
 		filtered, err := coordinator.PreProcess(context.Background(), []ocr2keepers.UpkeepPayload{
 			{
+				WorkID: "123",
 				Upkeep: ocr2keepers.ConfiguredUpkeep{
 					ID: []byte("123"),
 				},
@@ -593,6 +598,7 @@ func TestConditionalReportCoordinator_PreProcess(t *testing.T) {
 				},
 			},
 			{
+				WorkID: "456",
 				Upkeep: ocr2keepers.ConfiguredUpkeep{
 					ID: []byte("456"),
 				},
@@ -601,6 +607,7 @@ func TestConditionalReportCoordinator_PreProcess(t *testing.T) {
 				},
 			},
 			{
+				WorkID: "789",
 				Upkeep: ocr2keepers.ConfiguredUpkeep{
 					ID: []byte("789"),
 				},
@@ -627,6 +634,7 @@ func TestConditionalReportCoordinator_checkEvents(t *testing.T) {
 					TransmitBlock: ocr2keepers.BlockKey("123"),
 					Type:          ocr2keepers.PerformEvent,
 					UpkeepID:      ocr2keepers.UpkeepIdentifier("10"),
+					WorkID:        "10",
 					CheckBlock:    ocr2keepers.BlockKey("123"),
 				},
 				{
@@ -634,6 +642,7 @@ func TestConditionalReportCoordinator_checkEvents(t *testing.T) {
 					TransmitBlock: ocr2keepers.BlockKey("124"),
 					Type:          ocr2keepers.StaleReportEvent,
 					UpkeepID:      ocr2keepers.UpkeepIdentifier("20"),
+					WorkID:        "20",
 					CheckBlock:    ocr2keepers.BlockKey("124"),
 				},
 				{
@@ -641,6 +650,7 @@ func TestConditionalReportCoordinator_checkEvents(t *testing.T) {
 					TransmitBlock: ocr2keepers.BlockKey("200"),
 					Type:          ocr2keepers.StaleReportEvent,
 					UpkeepID:      ocr2keepers.UpkeepIdentifier("30"),
+					WorkID:        "30",
 					CheckBlock:    ocr2keepers.BlockKey("200"),
 				},
 			}, nil

--- a/pkg/v3/coordinator/log_event_coordinator_test.go
+++ b/pkg/v3/coordinator/log_event_coordinator_test.go
@@ -32,7 +32,8 @@ func TestLogEventCoordinator(t *testing.T) {
 	t.Run("Accept", func(t *testing.T) {
 		rc, _ := setup(t, log.New(io.Discard, "nil", 0))
 		upkeep := ocr2keepers.ReportedUpkeep{
-			ID: "your-upkeep-id",
+			ID:     "your-upkeep-id",
+			WorkID: "your-upkeep-id",
 			Trigger: ocr2keepers.Trigger{
 				Extension: map[string]interface{}{
 					"txHash": "your-tx-hash",
@@ -47,6 +48,7 @@ func TestLogEventCoordinator(t *testing.T) {
 	t.Run("IsLogEventUpkeep", func(t *testing.T) {
 		rc, _ := setup(t, log.New(io.Discard, "nil", 0))
 		upkeep_true := ocr2keepers.ReportedUpkeep{
+			WorkID: "work-id",
 			Trigger: ocr2keepers.Trigger{
 				Extension: map[string]interface{}{
 					"txHash": "your-tx-hash",
@@ -58,6 +60,7 @@ func TestLogEventCoordinator(t *testing.T) {
 		assert.True(t, result, "expected true for log event-based upkeep")
 
 		upkeep_false := ocr2keepers.ReportedUpkeep{
+			WorkID: "work-id",
 			Trigger: ocr2keepers.Trigger{
 				Extension: "invalid",
 			},
@@ -87,7 +90,8 @@ func TestLogEventCoordinator(t *testing.T) {
 	t.Run("Perform Event", func(t *testing.T) {
 		rc, _ := setup(t, log.New(io.Discard, "nil", 0))
 		evt := ocr2keepers.TransmitEvent{
-			ID: "your-event-id",
+			ID:     "your-event-id",
+			WorkID: "your-event-id",
 		}
 
 		rc.performEvent(evt)
@@ -103,9 +107,9 @@ func TestLogEventCoordinator(t *testing.T) {
 
 		// Define some example payloads
 		payloads := []ocr2keepers.UpkeepPayload{
-			{ID: "payload1"},
-			{ID: "payload2"},
-			{ID: "payload3"},
+			{ID: "payload1", WorkID: "payload1"},
+			{ID: "payload2", WorkID: "payload2"},
+			{ID: "payload3", WorkID: "payload3"},
 		}
 
 		// Call the PreProcess git st
@@ -114,8 +118,8 @@ func TestLogEventCoordinator(t *testing.T) {
 
 		// Assert that only payload2 and payload3 are included in the filteredPayloads slice
 		expectedPayloads := []ocr2keepers.UpkeepPayload{
-			{ID: "payload2"},
-			{ID: "payload3"},
+			{ID: "payload2", WorkID: "payload2"},
+			{ID: "payload3", WorkID: "payload3"},
 		}
 		assert.Equal(t, expectedPayloads, filteredPayloads, "filteredPayloads should match the expected payloads")
 	})

--- a/pkg/v3/resultstore/store.go
+++ b/pkg/v3/resultstore/store.go
@@ -89,13 +89,13 @@ func (s *resultStore) Add(results ...ocr2keepers.CheckResult) {
 
 	added := 0
 	for _, r := range results {
-		id := r.Payload.ID
+		id := r.Payload.WorkID
 		_, ok := s.data[id]
 		if !ok {
 			added++
 			s.data[id] = result{data: r, addedAt: time.Now()}
 
-			s.lggr.Printf("result added for upkeep id '%s' and trigger '%s'", string(r.Payload.Upkeep.ID), r.Payload.ID)
+			s.lggr.Printf("result added for upkeep id '%s', trigger '%s', and work id '%s'", string(r.Payload.Upkeep.ID), r.Payload.ID, r.Payload.WorkID)
 		}
 		// if the element is already exists, we do noting
 	}

--- a/pkg/v3/resultstore/store_test.go
+++ b/pkg/v3/resultstore/store_test.go
@@ -329,7 +329,8 @@ func mockItems(i, count int) []ocr2keepers.CheckResult {
 		items[j] = ocr2keepers.CheckResult{
 			Retryable: false,
 			Payload: ocr2keepers.UpkeepPayload{
-				ID: fmt.Sprintf("test-id-%d", i+j),
+				ID:     fmt.Sprintf("test-id-%d", i+j),
+				WorkID: fmt.Sprintf("test-id-%d", i+j),
 			},
 		}
 	}


### PR DESCRIPTION
This commit adds a new property to UpkeepPayload, TransmitEvent, and ReportedUpkeep. All three structs have an ID and should have a corresponding WorkID to identify the upkeep at different stages of the pipeline.

Also included in this commit is removing CheckBlock from UpkeepPayload to help avoid confusion over unused properties.