### PR TITLE
update quorum requirements to include F

### DIFF
--- a/pkg/v3/plugin/factory.go
+++ b/pkg/v3/plugin/factory.go
@@ -114,6 +114,7 @@ func (factory *pluginFactory) NewOCR3Plugin(c ocr3types.OCR3PluginConfig) (ocr3t
 		factory.runnable,
 		factory.runnerConf,
 		conf,
+		c.F,
 		factory.logger,
 	)
 	if err != nil {

--- a/pkg/v3/plugin/ocr3.go
+++ b/pkg/v3/plugin/ocr3.go
@@ -44,6 +44,7 @@ type ocr3Plugin struct {
 	Coordinators  []Coordinator
 	Services      []service.Recoverable
 	Config        config.OffchainConfig
+	F             int
 	Logger        *log.Logger
 }
 
@@ -109,10 +110,10 @@ func (plugin *ocr3Plugin) ValidateObservation(outctx ocr3types.OutcomeContext, q
 }
 
 func (plugin *ocr3Plugin) Outcome(outctx ocr3types.OutcomeContext, query types.Query, attributedObservations []types.AttributedObservation) (ocr3types.Outcome, error) {
-	p := newPerformables(len(attributedObservations) / 2)
+	p := newPerformables(plugin.F + 1)
 	c := newCoordinateBlock(len(attributedObservations) / 2)
 	s := newSamples(OutcomeSamplesLimit, getRandomKeySource(plugin.ConfigDigest, outctx.SeqNr))
-	r := newRecoverables(len(attributedObservations) / 2)
+	r := newRecoverables(plugin.F + 1)
 
 	// extract observations and pass them on to evaluators
 	for _, attributedObservation := range attributedObservations {

--- a/pkg/v3/plugin/plugin.go
+++ b/pkg/v3/plugin/plugin.go
@@ -38,6 +38,7 @@ func newPlugin(
 	runnable runner.Runnable,
 	rConf runner.RunnerConfig,
 	conf config.OffchainConfig,
+	f int,
 	logger *log.Logger,
 ) (ocr3types.OCR3Plugin[AutomationReportInfo], error) {
 	blockTicker, err := tickers.NewBlockTicker(blockSource)
@@ -131,6 +132,7 @@ func newPlugin(
 		Coordinators:  []Coordinator{coord},
 		Services:      recoverSvcs,
 		Config:        conf,
+		F:             f,
 		Logger:        log.New(logger.Writer(), fmt.Sprintf("[%s | plugin]", telemetry.ServiceName), telemetry.LogPkgStdFlags),
 	}
 


### PR DESCRIPTION
The current quorum requirements for specific agreements revolve around 'F' or the number of allowable faulty nodes. This commit passed 'F' from the configuration to the plugin and passes the defined quorum requirements to the agreement functions.