### PR TITLE
Disable build hooks for happy path

### DIFF
--- a/pkg/v3/plugin/plugin.go
+++ b/pkg/v3/plugin/plugin.go
@@ -124,9 +124,10 @@ func newPlugin(
 		},
 		BuildHooks: []func(*ocr2keepersv3.AutomationObservation) error{
 			build.NewAddFromStaging(rs, logger).RunHook,
-			build.NewCoordinateBlockHook(is, ms).RunHook,
-			build.NewAddFromRecoveryHook(ms).RunHook,
-			build.NewAddFromSamplesHook(ms).RunHook,
+			// TODO: AUTO-4243 Finalize build hooks
+			//build.NewCoordinateBlockHook(is, ms).RunHook,
+			//build.NewAddFromRecoveryHook(ms).RunHook,
+			//build.NewAddFromSamplesHook(ms).RunHook,
 		},
 		ReportEncoder: encoder,
 		Coordinators:  []Coordinator{coord},


### PR DESCRIPTION
The build hooks are currently returning the error
```
logger.go:130: 2023-08-04T20:39:40.796+0100	ERROR	OCR2	protocol/common.go:39	call to ReportingPlugin.Observation errored	{"version": "unset@unset", "jobID": 1, "jobName": "ocr2keepers-3", "contractID": "0x0a64d095078b02b8B91eB9c3450817Bf819f44D2", "transmitterID": "0x4F3F8B86761Abcda18C7351d78d8B2dEF859d22A", "evmChainID": 1337, "e": 45, "l": 2, "configDigest": "000136d36e3e31ab92f685c403e9b91ae56b8d8b03a7b1db9b91e453a4bbe486", "oid": 3, "error": "proposal recovery metadata unavailable", "seqNr": 1, "round": 1, "proto": "outgen"}
```
Commenting them out for now for happy path, they need to be completely overhauled