### PR TITLE
make CheckResult print fields in human-readable format

### DIFF
--- a/pkg/v3/types/basetypes.go
+++ b/pkg/v3/types/basetypes.go
@@ -1,9 +1,31 @@
 package types
 
 import (
+	"encoding/hex"
 	"fmt"
 	"math/big"
+	"strings"
 )
+
+var checkResultStringTemplate = `{
+	"PipelineExecutionState":%d,
+	"Retryable":%v,
+	"Eligible":%v,
+	"IneligibilityReason":%d,
+	"UpkeepID":%s,
+	"Trigger":%s,
+	"WorkID":"%s",
+	"GasAllocated":%d,
+	"PerformData":"%s",
+	"FastGasWei":%s,
+	"LinkNative":%s
+}`
+
+func init() {
+	checkResultStringTemplate = strings.Replace(checkResultStringTemplate, " ", "", -1)
+	checkResultStringTemplate = strings.Replace(checkResultStringTemplate, "\t", "", -1)
+	checkResultStringTemplate = strings.Replace(checkResultStringTemplate, "\n", "", -1)
+}
 
 type UpkeepType uint8
 
@@ -37,6 +59,7 @@ const (
 // UpkeepIdentifier is a unique identifier for the upkeep, represented as uint256 in the contract.
 type UpkeepIdentifier [32]byte
 
+// String returns a base 10 numerical string representation of the upkeep identifier.
 func (u UpkeepIdentifier) String() string {
 	return u.BigInt().String()
 }
@@ -148,6 +171,14 @@ func (r CheckResult) UniqueID() string {
 	resultBytes = append(resultBytes, r.FastGasWei.Bytes()...)
 	resultBytes = append(resultBytes, r.LinkNative.Bytes()...)
 	return fmt.Sprintf("%x", resultBytes)
+}
+
+func (r CheckResult) String() string {
+	return fmt.Sprintf(
+		checkResultStringTemplate, r.PipelineExecutionState, r.Retryable, r.Eligible,
+		r.IneligibilityReason, r.UpkeepID, r.Trigger, r.WorkID, r.GasAllocated,
+		hex.EncodeToString(r.PerformData), r.FastGasWei, r.LinkNative,
+	)
 }
 
 // BlockHistory is a list of block keys

--- a/pkg/v3/types/trigger.go
+++ b/pkg/v3/types/trigger.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"bytes"
+	"encoding/hex"
 	"fmt"
 )
 
@@ -19,6 +20,15 @@ type Trigger struct {
 	BlockHash [32]byte
 	// LogTriggerExtension is the extension for log triggers
 	LogTriggerExtension *LogTriggerExtension
+}
+
+func (r Trigger) String() string {
+	res := fmt.Sprintf(`{"BlockNumber":%d,"BlockHash":"%s"`, r.BlockNumber, hex.EncodeToString(r.BlockHash[:]))
+	if r.LogTriggerExtension != nil {
+		res += fmt.Sprintf(`,"LogTriggerExtension":%s`, r.LogTriggerExtension)
+	}
+	res += "}"
+	return res
 }
 
 // NewTrigger returns a new basic trigger w/o extension
@@ -65,4 +75,11 @@ func (e LogTriggerExtension) LogIdentifier() []byte {
 		e.TxHash[:],
 		[]byte(fmt.Sprintf("%d", e.Index)),
 	}, []byte{})
+}
+
+func (e LogTriggerExtension) String() string {
+	return fmt.Sprintf(
+		`{"BlockHash":"%s","BlockNumber":%d,"Index":%d,"TxHash":"%s"}`,
+		hex.EncodeToString(e.BlockHash[:]), e.BlockNumber, e.Index, hex.EncodeToString(e.TxHash[:]),
+	)
 }


### PR DESCRIPTION
adds `String()` methods to the following structs:
* `CheckResult`
* `Trigger`
* `LogTriggerExtension`