### PR TITLE
Fix uint32 encoding in log identifier

### DIFF
--- a/pkg/v3/types/basetypes_test.go
+++ b/pkg/v3/types/basetypes_test.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"math/big"
@@ -87,6 +88,20 @@ func TestTriggerString(t *testing.T) {
 	expected = `{"BlockNumber":5,"BlockHash":"0102030401020304010203040102030401020304010203040102030401020304"}`
 
 	assertJSONEqual(t, expected, stringified)
+}
+
+func TestLogIdentifier(t *testing.T) {
+	input := Trigger{
+		BlockNumber: 5,
+		BlockHash:   [32]byte{1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4},
+		LogTriggerExtension: &LogTriggerExtension{
+			TxHash: [32]byte{1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4},
+			Index:  99,
+		},
+	}
+
+	logIdentifier := input.LogTriggerExtension.LogIdentifier()
+	assert.Equal(t, hex.EncodeToString(logIdentifier), "010203040102030401020304010203040102030401020304010203040102030400000063")
 }
 
 func TestTriggerUnmarshal_EmptyExtension(t *testing.T) {

--- a/pkg/v3/types/trigger.go
+++ b/pkg/v3/types/trigger.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"bytes"
+	"encoding/binary"
 	"encoding/hex"
 	"fmt"
 )
@@ -71,9 +72,11 @@ type LogTriggerExtension struct {
 // LogIdentifier returns a unique identifier for the log event,
 // composed of the transaction hash and the log index bytes.
 func (e LogTriggerExtension) LogIdentifier() []byte {
+	indexBytes := make([]byte, 4) // uint32 is 4 bytes
+	binary.BigEndian.PutUint32(indexBytes, e.Index)
 	return bytes.Join([][]byte{
 		e.TxHash[:],
-		[]byte(fmt.Sprintf("%d", e.Index)),
+		indexBytes,
 	}, []byte{})
 }
 


### PR DESCRIPTION
Instead of printing index into a string, place it into bytes4 which is consistent with contract