### PR TITLE
Coordinator fixes

### DIFF
--- a/pkg/v3/coordinator/coordinator.go
+++ b/pkg/v3/coordinator/coordinator.go
@@ -74,7 +74,7 @@ func (c *coordinator) ShouldTransmit(reportedUpkeep ocr2keepers.ReportedUpkeep) 
 		// We already accepted a report for a higher checkBlockNumber, so don't try to transmit
 		return false
 	} else if reportedUpkeep.Trigger.BlockNumber == v.checkBlockNumber {
-		return true
+		return v.isTransmissionPending
 	} else {
 		// We never saw this report for such a high block number, so don't try to transmit
 		// Can happen in edge cases when plugin restarts after shouldAccept was called

--- a/pkg/v3/coordinator/coordinator_test.go
+++ b/pkg/v3/coordinator/coordinator_test.go
@@ -471,10 +471,11 @@ func TestCoordinator_ShouldTransmit(t *testing.T) {
 			shouldTransmit: false,
 		},
 		{
-			name: "if the given work ID does exist in the cache, and the reported upkeep's check block is equal to the cached check block, we should transmit",
+			name: "if the given work ID does exist in the cache, and the reported upkeep's check block is equal to the cached check block, and transmission is pending, we should transmit",
 			cacheInit: map[string]record{
 				"workID1": {
-					checkBlockNumber: 200,
+					checkBlockNumber:      200,
+					isTransmissionPending: true,
 				},
 			},
 			reportedUpkeep: ocr2keepers.ReportedUpkeep{
@@ -484,6 +485,22 @@ func TestCoordinator_ShouldTransmit(t *testing.T) {
 				},
 			},
 			shouldTransmit: true,
+		},
+		{
+			name: "if the given work ID does exist in the cache, and the reported upkeep's check block is equal to the cached check block, and transmission is not pending, we should transmit",
+			cacheInit: map[string]record{
+				"workID1": {
+					checkBlockNumber:      200,
+					isTransmissionPending: false,
+				},
+			},
+			reportedUpkeep: ocr2keepers.ReportedUpkeep{
+				WorkID: "workID1",
+				Trigger: ocr2keepers.Trigger{
+					BlockNumber: 200,
+				},
+			},
+			shouldTransmit: false,
 		},
 		{
 			name: "if the given work ID does exist in the cache, and the reported upkeep's check block is greater than the cached check block, we should not transmit",


### PR DESCRIPTION
in shouldTransmit, return true only if the reported upkeep is pending transmission, o/w all transmitters will try to transmit