### PR TITLE
Improve logging in coordinator

### DIFF
--- a/pkg/v3/coordinator/coordinator.go
+++ b/pkg/v3/coordinator/coordinator.go
@@ -2,6 +2,7 @@ package coordinator
 
 import (
 	"context"
+	"encoding/hex"
 	"fmt"
 	"log"
 	"time"
@@ -167,9 +168,9 @@ func (c *coordinator) checkEvents(ctx context.Context) error {
 
 		if v, ok := c.cache.Get(event.WorkID); ok {
 			if event.CheckBlock < v.checkBlockNumber {
-				c.logger.Printf("Ignoring event in transaction %s from older report (block %v) while waiting for (block %v)", event.TransactionHash, event.CheckBlock, v.checkBlockNumber)
+				c.logger.Printf("Ignoring event in transaction %s from older report (block %v) while waiting for (block %v)", hex.EncodeToString(event.TransactionHash[:]), event.CheckBlock, v.checkBlockNumber)
 			} else if event.CheckBlock == v.checkBlockNumber {
-				c.logger.Printf("Got event in transaction %s of type %d for workID %s and check block %v", event.TransactionHash, event.Type, event.WorkID, event.CheckBlock)
+				c.logger.Printf("Got event in transaction %s of type %d for workID %s and check block %v", hex.EncodeToString(event.TransactionHash[:]), event.Type, event.WorkID, event.CheckBlock)
 				c.cache.Set(event.WorkID, record{
 					checkBlockNumber:      v.checkBlockNumber,
 					isTransmissionPending: false,
@@ -177,7 +178,7 @@ func (c *coordinator) checkEvents(ctx context.Context) error {
 					transmitBlockNumber:   event.TransmitBlock,
 				}, util.DefaultCacheExpiration)
 			} else {
-				c.logger.Printf("Got event in transaction %s from newer report (block %v) while waiting for (block %v)", event.TransactionHash, event.CheckBlock, v.checkBlockNumber)
+				c.logger.Printf("Got event in transaction %s from newer report (block %v) while waiting for (block %v)", hex.EncodeToString(event.TransactionHash[:]), event.CheckBlock, v.checkBlockNumber)
 				c.cache.Set(event.WorkID, record{
 					checkBlockNumber:      event.CheckBlock,
 					isTransmissionPending: false,


### PR DESCRIPTION
Instead of logging a byte array, encode to hex first