### PR TITLE
Update result store and retry queue on same block number

### DIFF
--- a/pkg/v3/stores/result_store.go
+++ b/pkg/v3/stores/result_store.go
@@ -85,7 +85,7 @@ func (s *resultStore) Add(results ...ocr2keepers.CheckResult) {
 		if !ok {
 			s.data[r.WorkID] = result{data: r, addedAt: time.Now()}
 			s.lggr.Printf("Result added for upkeep id '%s' and trigger '%+v'", r.UpkeepID.String(), r.Trigger)
-		} else if v.data.Trigger.BlockNumber < r.Trigger.BlockNumber {
+		} else if v.data.Trigger.BlockNumber <= r.Trigger.BlockNumber {
 			// result is newer -> replace existing data
 			s.data[r.WorkID] = result{data: r, addedAt: time.Now()}
 			s.lggr.Printf("Result updated for upkeep id '%s' to higher check block from (%d) to trigger '%+v'", r.UpkeepID.String(), v.data.Trigger.BlockNumber, r.Trigger)

--- a/pkg/v3/stores/retry_queue.go
+++ b/pkg/v3/stores/retry_queue.go
@@ -69,7 +69,7 @@ func (q *retryQueue) Enqueue(payloads ...types.UpkeepPayload) error {
 				createdAt: now,
 			}
 		}
-		if payload.Trigger.BlockNumber > record.payload.Trigger.BlockNumber {
+		if payload.Trigger.BlockNumber >= record.payload.Trigger.BlockNumber {
 			// new item is newer -> replace payload
 			q.lggr.Printf("updating payload for workID %s on block %d", payload.WorkID, payload.Trigger.BlockNumber)
 			record.payload = payload


### PR DESCRIPTION
There's an edge case where a tx with a certain txHash can get reorged onto the same block number but a different blockHash. Since the log would then generate the same workID, it will be checked again on the same checkBlockNumber (but different hash). Allow the result / retry queue to be updated in case this happens