### PR TITLE
Random sources for v3

### DIFF
--- a/pkg/v3/flows/conditional.go
+++ b/pkg/v3/flows/conditional.go
@@ -6,10 +6,10 @@ import (
 	"log"
 	"time"
 
-	"github.com/smartcontractkit/ocr2keepers/internal/util"
 	ocr2keepersv3 "github.com/smartcontractkit/ocr2keepers/pkg/v3"
 	"github.com/smartcontractkit/ocr2keepers/pkg/v3/postprocessors"
 	"github.com/smartcontractkit/ocr2keepers/pkg/v3/preprocessors"
+	"github.com/smartcontractkit/ocr2keepers/pkg/v3/random"
 	"github.com/smartcontractkit/ocr2keepers/pkg/v3/service"
 	"github.com/smartcontractkit/ocr2keepers/pkg/v3/telemetry"
 	"github.com/smartcontractkit/ocr2keepers/pkg/v3/tickers"
@@ -60,7 +60,7 @@ func NewSampler(
 		logger:   logger,
 		getter:   getter,
 		ratio:    ratio,
-		shuffler: util.Shuffler[ocr2keepers.UpkeepPayload]{Source: util.NewCryptoRandSource()},
+		shuffler: random.Shuffler[ocr2keepers.UpkeepPayload]{Source: random.NewCryptoRandSource()},
 	}
 }
 

--- a/pkg/v3/plugin/coordinated_block_proposals.go
+++ b/pkg/v3/plugin/coordinated_block_proposals.go
@@ -4,8 +4,8 @@ import (
 	"log"
 	"sort"
 
-	"github.com/smartcontractkit/ocr2keepers/internal/util"
 	ocr2keepersv3 "github.com/smartcontractkit/ocr2keepers/pkg/v3"
+	"github.com/smartcontractkit/ocr2keepers/pkg/v3/random"
 	ocr2keepers "github.com/smartcontractkit/ocr2keepers/pkg/v3/types"
 )
 
@@ -121,7 +121,7 @@ func (c *coordinatedBlockProposals) set(outcome *ocr2keepersv3.AutomationOutcome
 
 	// Sort by a shuffled workID.
 	sort.Slice(latestProposals, func(i, j int) bool {
-		return util.ShuffleString(latestProposals[i].WorkID, c.keyRandSource) < util.ShuffleString(latestProposals[j].WorkID, c.keyRandSource)
+		return random.ShuffleString(latestProposals[i].WorkID, c.keyRandSource) < random.ShuffleString(latestProposals[j].WorkID, c.keyRandSource)
 	})
 	if len(latestProposals) > c.perRoundLimit {
 		c.logger.Printf("Limiting new proposals in outcome to %d", c.perRoundLimit)

--- a/pkg/v3/plugin/hooks/add_conditional_proposals.go
+++ b/pkg/v3/plugin/hooks/add_conditional_proposals.go
@@ -5,8 +5,8 @@ import (
 	"log"
 	"math/rand"
 
-	"github.com/smartcontractkit/ocr2keepers/internal/util"
 	ocr2keepersv3 "github.com/smartcontractkit/ocr2keepers/pkg/v3"
+	"github.com/smartcontractkit/ocr2keepers/pkg/v3/random"
 	"github.com/smartcontractkit/ocr2keepers/pkg/v3/telemetry"
 	"github.com/smartcontractkit/ocr2keepers/pkg/v3/types"
 )
@@ -36,7 +36,7 @@ func (h *AddConditionalProposalsHook) RunHook(obs *ocr2keepersv3.AutomationObser
 
 	// Do random shuffling. Sorting isn't done here as we don't require multiple nodes
 	// to agree on the same proposal, hence each node just sends a random subset of its proposals
-	rand.New(util.NewKeyedCryptoRandSource(rSrc)).Shuffle(len(conditionals), func(i, j int) {
+	rand.New(random.NewKeyedCryptoRandSource(rSrc)).Shuffle(len(conditionals), func(i, j int) {
 		conditionals[i], conditionals[j] = conditionals[j], conditionals[i]
 	})
 

--- a/pkg/v3/plugin/hooks/add_from_staging.go
+++ b/pkg/v3/plugin/hooks/add_from_staging.go
@@ -5,8 +5,8 @@ import (
 	"log"
 	"sort"
 
-	"github.com/smartcontractkit/ocr2keepers/internal/util"
 	ocr2keepersv3 "github.com/smartcontractkit/ocr2keepers/pkg/v3"
+	"github.com/smartcontractkit/ocr2keepers/pkg/v3/random"
 	"github.com/smartcontractkit/ocr2keepers/pkg/v3/telemetry"
 	"github.com/smartcontractkit/ocr2keepers/pkg/v3/types"
 	ocr2keepers "github.com/smartcontractkit/ocr2keepers/pkg/v3/types"
@@ -41,7 +41,7 @@ func (hook *AddFromStagingHook) RunHook(obs *ocr2keepersv3.AutomationObservation
 	// send the same subset of workIDs if they are available, while giving different priority
 	// to workIDs in different rounds.
 	sort.Slice(results, func(i, j int) bool {
-		return util.ShuffleString(results[i].WorkID, rSrc) < util.ShuffleString(results[j].WorkID, rSrc)
+		return random.ShuffleString(results[i].WorkID, rSrc) < random.ShuffleString(results[j].WorkID, rSrc)
 	})
 	if len(results) > limit {
 		results = results[:limit]

--- a/pkg/v3/plugin/hooks/add_log_proposals.go
+++ b/pkg/v3/plugin/hooks/add_log_proposals.go
@@ -5,8 +5,8 @@ import (
 	"log"
 	"math/rand"
 
-	"github.com/smartcontractkit/ocr2keepers/internal/util"
 	ocr2keepersv3 "github.com/smartcontractkit/ocr2keepers/pkg/v3"
+	"github.com/smartcontractkit/ocr2keepers/pkg/v3/random"
 	"github.com/smartcontractkit/ocr2keepers/pkg/v3/telemetry"
 	"github.com/smartcontractkit/ocr2keepers/pkg/v3/types"
 )
@@ -36,7 +36,7 @@ func (h *AddLogProposalsHook) RunHook(obs *ocr2keepersv3.AutomationObservation, 
 
 	// Do random shuffling. Sorting isn't done here as we don't require multiple nodes
 	// to agree on the same proposal, hence each node just sends a random subset of its proposals
-	rand.New(util.NewKeyedCryptoRandSource(rSrc)).Shuffle(len(proposals), func(i, j int) {
+	rand.New(random.NewKeyedCryptoRandSource(rSrc)).Shuffle(len(proposals), func(i, j int) {
 		proposals[i], proposals[j] = proposals[j], proposals[i]
 	})
 

--- a/pkg/v3/plugin/ocr3.go
+++ b/pkg/v3/plugin/ocr3.go
@@ -2,18 +2,17 @@ package plugin
 
 import (
 	"context"
-	"encoding/binary"
 	"errors"
 	"fmt"
 	"log"
 
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3types"
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/types"
-	"golang.org/x/crypto/sha3"
 
 	ocr2keepersv3 "github.com/smartcontractkit/ocr2keepers/pkg/v3"
 	"github.com/smartcontractkit/ocr2keepers/pkg/v3/config"
 	"github.com/smartcontractkit/ocr2keepers/pkg/v3/plugin/hooks"
+	"github.com/smartcontractkit/ocr2keepers/pkg/v3/random"
 	"github.com/smartcontractkit/ocr2keepers/pkg/v3/service"
 	ocr2keepers "github.com/smartcontractkit/ocr2keepers/pkg/v3/types"
 )
@@ -257,16 +256,8 @@ func (plugin *ocr3Plugin) getReportFromPerformables(toPerform []ocr2keepers.Chec
 }
 
 // Generates a randomness source derived from the config and seq # so
-// that it's the same across the network for the same round
+// that it's the same across the network for the same round.
+// similar key building as libocr transmit selector.
 func getRandomKeySource(cd types.ConfigDigest, seqNr uint64) [16]byte {
-	// similar key building as libocr transmit selector
-	hash := sha3.NewLegacyKeccak256()
-	hash.Write(cd[:])
-	temp := make([]byte, 8)
-	binary.LittleEndian.PutUint64(temp, seqNr)
-	hash.Write(temp)
-
-	var keyRandSource [16]byte
-	copy(keyRandSource[:], hash.Sum(nil))
-	return keyRandSource
+	return random.GetRandomKeySource(cd[:], seqNr)
 }

--- a/pkg/v3/plugin/performable.go
+++ b/pkg/v3/plugin/performable.go
@@ -4,8 +4,8 @@ import (
 	"log"
 	"sort"
 
-	"github.com/smartcontractkit/ocr2keepers/internal/util"
 	ocr2keepersv3 "github.com/smartcontractkit/ocr2keepers/pkg/v3"
+	"github.com/smartcontractkit/ocr2keepers/pkg/v3/random"
 	ocr2keepers "github.com/smartcontractkit/ocr2keepers/pkg/v3/types"
 )
 
@@ -79,7 +79,7 @@ func (p *performables) set(outcome *ocr2keepersv3.AutomationOutcome) {
 
 	// Sort by a shuffled workID.
 	sort.Slice(performable, func(i, j int) bool {
-		return util.ShuffleString(performable[i].WorkID, p.keyRandSource) < util.ShuffleString(performable[j].WorkID, p.keyRandSource)
+		return random.ShuffleString(performable[i].WorkID, p.keyRandSource) < random.ShuffleString(performable[j].WorkID, p.keyRandSource)
 	})
 
 	if len(performable) > p.limit {

--- a/pkg/v3/random/shuffler.go
+++ b/pkg/v3/random/shuffler.go
@@ -1,0 +1,23 @@
+package random
+
+import "math/rand"
+
+type Shuffler[T any] struct {
+	Source rand.Source
+}
+
+func (s Shuffler[T]) Shuffle(a []T) []T {
+	r := rand.New(s.Source)
+	r.Shuffle(len(a), func(i, j int) {
+		a[i], a[j] = a[j], a[i]
+	})
+	return a
+}
+
+func ShuffleString(s string, rSrc [16]byte) string {
+	shuffled := []rune(s)
+	rand.New(NewKeyedCryptoRandSource(rSrc)).Shuffle(len(shuffled), func(i, j int) {
+		shuffled[i], shuffled[j] = shuffled[j], shuffled[i]
+	})
+	return string(shuffled)
+}

--- a/pkg/v3/random/shuffler_test.go
+++ b/pkg/v3/random/shuffler_test.go
@@ -1,0 +1,36 @@
+package random
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestShuffler_Shuffle(t *testing.T) {
+	shuffler := Shuffler[int]{Source: rand.NewSource(0)}
+	arr := []int{1, 2, 3, 4, 5}
+	arr = shuffler.Shuffle(arr)
+	assert.Equal(t, arr, []int{3, 4, 2, 1, 5})
+
+	// Sorting again using a used shuffler should yield a different result
+	arr = []int{1, 2, 3, 4, 5}
+	arr = shuffler.Shuffle(arr)
+	assert.Equal(t, arr, []int{3, 4, 1, 5, 2})
+
+	// Sorting again using a new shuffler with the same pseudo-random source should yield the same result
+	shuffler2 := Shuffler[int]{Source: rand.NewSource(0)}
+	arr2 := []int{1, 2, 3, 4, 5}
+	arr2 = shuffler2.Shuffle(arr2)
+	assert.Equal(t, arr2, []int{3, 4, 2, 1, 5})
+}
+
+func TestShuffler_ShuffleString(t *testing.T) {
+	assert.Equal(t, ShuffleString("12345", [16]byte{0}), "14523")
+	// ShuffleString should be deterministic based on rSrc
+	assert.Equal(t, ShuffleString("12345", [16]byte{0}), "14523")
+	assert.Equal(t, ShuffleString("12345", [16]byte{1}), "51243")
+	assert.Equal(t, ShuffleString("123456", [16]byte{0}), "516423")
+	assert.Equal(t, ShuffleString("", [16]byte{0}), "")
+	assert.Equal(t, ShuffleString("dsv$\u271387csdv0-`", [16]byte{0}), "d0v`$-8vsscd\u27137")
+}

--- a/pkg/v3/random/src.go
+++ b/pkg/v3/random/src.go
@@ -1,0 +1,76 @@
+package random
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	crand "crypto/rand"
+	"encoding/binary"
+	"math/rand"
+
+	"golang.org/x/crypto/sha3"
+)
+
+var (
+	newCipherFn = aes.NewCipher
+	randReadFn  = crand.Read
+)
+
+// Generates a randomness source derived from the prefix and seq # so
+// that it's the same across the network for the same input.
+func GetRandomKeySource(prefix []byte, seq uint64) [16]byte {
+	// similar key building as libocr transmit selector
+	hash := sha3.NewLegacyKeccak256()
+	hash.Write(prefix[:])
+	temp := make([]byte, 8)
+	binary.LittleEndian.PutUint64(temp, seq)
+	hash.Write(temp)
+
+	var keyRandSource [16]byte
+	copy(keyRandSource[:], hash.Sum(nil))
+	return keyRandSource
+}
+
+type keyedCryptoRandSource struct {
+	stream cipher.Stream
+}
+
+func NewKeyedCryptoRandSource(key [16]byte) rand.Source {
+	var iv [16]byte // zero IV is fine here
+	block, err := newCipherFn(key[:])
+	if err != nil {
+		// assertion
+		panic(err)
+	}
+	return &keyedCryptoRandSource{cipher.NewCTR(block, iv[:])}
+}
+
+const int63Mask = 1<<63 - 1
+
+func (crs *keyedCryptoRandSource) Int63() int64 {
+	var buf [8]byte
+	crs.stream.XORKeyStream(buf[:], buf[:])
+	return int64(binary.LittleEndian.Uint64(buf[:]) & int63Mask)
+}
+
+func (crs *keyedCryptoRandSource) Seed(seed int64) {
+	panic("keyedCryptoRandSource.Seed: Not supported")
+}
+
+type cryptoRandSource struct{}
+
+func NewCryptoRandSource() rand.Source {
+	return cryptoRandSource{}
+}
+
+func (_ cryptoRandSource) Int63() int64 {
+	var b [8]byte
+	_, err := randReadFn(b[:])
+	if err != nil {
+		panic(err)
+	}
+	return int64(binary.LittleEndian.Uint64(b[:]) & (1<<63 - 1))
+}
+
+func (_ cryptoRandSource) Seed(_ int64) {
+	panic("cryptoRandSource.Seed: Not supported")
+}

--- a/pkg/v3/random/src_test.go
+++ b/pkg/v3/random/src_test.go
@@ -1,0 +1,107 @@
+package random
+
+import (
+	"crypto/cipher"
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_GetRandomKeySource(t *testing.T) {
+	tests := []struct {
+		name   string
+		prefix []byte
+		seq    uint64
+		want   [16]byte
+	}{
+		{
+			name:   "happy path",
+			prefix: []byte{1, 2, 3, 4},
+			seq:    1234,
+			want:   [16]byte{0x3e, 0xb0, 0x60, 0xd8, 0x59, 0x17, 0x19, 0xd, 0x80, 0x60, 0x41, 0xd4, 0x61, 0xaa, 0x5f, 0x12},
+		},
+		{
+			name:   "nil prefix",
+			prefix: nil,
+			seq:    1234,
+			want:   [16]byte{0x44, 0x36, 0xac, 0xd0, 0x86, 0xda, 0xf2, 0xaf, 0xf2, 0xd9, 0x40, 0xaf, 0x64, 0xf6, 0xb8, 0x84},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, GetRandomKeySource(tc.prefix, tc.seq))
+		})
+	}
+}
+
+func TestCryptoRandSource(t *testing.T) {
+	t.Run("creates a new CryptoRandSource", func(t *testing.T) {
+		s := NewCryptoRandSource()
+		i := s.Int63()
+		assert.NotEqual(t, 0, i)
+	})
+
+	t.Run("panics on Seed", func(t *testing.T) {
+		defer func() {
+			if r := recover(); r == nil {
+				t.Fatalf("expected a panic, did not panic")
+			}
+		}()
+
+		s := NewCryptoRandSource()
+		s.Seed(int64(123))
+	})
+
+	t.Run("an error on crand.Read causes a panic", func(t *testing.T) {
+		oldRandReadFn := randReadFn
+		randReadFn = func(b []byte) (n int, err error) {
+			return 0, errors.New("read error")
+		}
+		defer func() {
+			randReadFn = oldRandReadFn
+		}()
+		defer func() {
+			if r := recover(); r == nil {
+				t.Fatalf("expected a panic, did not panic")
+			}
+		}()
+
+		s := NewCryptoRandSource()
+		s.Int63()
+	})
+}
+
+func TestNewKeyedCryptoRandSource(t *testing.T) {
+	t.Run("creates a new KeyedCryptoRandSource", func(t *testing.T) {
+		src := NewKeyedCryptoRandSource([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16})
+		i := src.Int63()
+		assert.Equal(t, i, int64(1590255750952055259))
+
+		defer func() {
+			if r := recover(); r == nil {
+				t.Fatalf("expected a panic, did not panic")
+			}
+		}()
+		src.Seed(99)
+	})
+
+	t.Run("fails to create a new KeyedCryptoRandSource due to invalid key size", func(t *testing.T) {
+		oldNewCipherFn := newCipherFn
+		newCipherFn = func(key []byte) (cipher.Block, error) {
+			return nil, errors.New("invalid key")
+		}
+		defer func() {
+			newCipherFn = oldNewCipherFn
+		}()
+
+		defer func() {
+			if r := recover(); r == nil {
+				t.Fatalf("expected a panic, did not panic")
+			}
+		}()
+
+		NewKeyedCryptoRandSource([16]byte{1})
+	})
+}


### PR DESCRIPTION
Exposed infra for working with random seed keys, to be used by log provider/recoverer to agree on random order to drop items in case of overflow.

**NOTE:** some code duplicates of `internal/util/rand.go` which is kept for v2 compatibility but should be cleaned in the future