### PR TITLE
Rename validate functions to ensureMininumDefaults

### DIFF
--- a/pkg/v3/config/config.go
+++ b/pkg/v3/config/config.go
@@ -80,12 +80,12 @@ func DecodeOffchainConfig(b []byte) (OffchainConfig, error) {
 	}
 
 	// ensure the defaults are applied at a minimum, for any values below the acceptable lower bound
-	ensureDefaults(&config)
+	ensureMinimumDefaults(&config)
 
 	return config, nil
 }
 
-func ensureDefaults(conf *OffchainConfig) {
+func ensureMinimumDefaults(conf *OffchainConfig) {
 	if conf.PerformLockoutWindow <= 0 {
 		// default of 20 minutes (100 blocks on eth)
 		conf.PerformLockoutWindow = 20 * 60 * 1000

--- a/pkg/v3/config/config.go
+++ b/pkg/v3/config/config.go
@@ -27,13 +27,13 @@ var (
 	// if a value is invalid, return an error but don't override it with the
 	// default
 	validators = []validator{
-		validatePerformLockoutWindow,
-		validateTargetProbability,
-		validateTargetInRounds,
-		validateMinConfirmations,
-		validateGasLimitPerReport,
-		validateGasOverheadPerUpkeep,
-		validateMaxUpkeepBatchSize,
+		defaultPerformLockoutWindow,
+		defaultTargetProbability,
+		defaultTargetInRounds,
+		defaultMinConfirmations,
+		defaultGasLimitPerReport,
+		defaultGasOverheadPerUpkeep,
+		defaultMaxUpkeepBatchSize,
 	}
 )
 
@@ -103,7 +103,7 @@ func DecodeOffchainConfig(b []byte) (OffchainConfig, error) {
 
 type validator func(*OffchainConfig) error
 
-func validatePerformLockoutWindow(conf *OffchainConfig) error {
+func defaultPerformLockoutWindow(conf *OffchainConfig) error {
 	if conf.PerformLockoutWindow <= 0 {
 		// default of 20 minutes (100 blocks on eth)
 		conf.PerformLockoutWindow = 20 * 60 * 1000
@@ -112,7 +112,7 @@ func validatePerformLockoutWindow(conf *OffchainConfig) error {
 	return nil
 }
 
-func validateTargetProbability(conf *OffchainConfig) error {
+func defaultTargetProbability(conf *OffchainConfig) error {
 	if len(conf.TargetProbability) == 0 {
 		conf.TargetProbability = "0.99999"
 	}
@@ -120,7 +120,7 @@ func validateTargetProbability(conf *OffchainConfig) error {
 	return nil
 }
 
-func validateTargetInRounds(conf *OffchainConfig) error {
+func defaultTargetInRounds(conf *OffchainConfig) error {
 	if conf.TargetInRounds <= 0 {
 		conf.TargetInRounds = 1
 	}
@@ -128,7 +128,7 @@ func validateTargetInRounds(conf *OffchainConfig) error {
 	return nil
 }
 
-func validateMinConfirmations(conf *OffchainConfig) error {
+func defaultMinConfirmations(conf *OffchainConfig) error {
 	if conf.MinConfirmations <= 0 {
 		conf.MinConfirmations = 0
 	}
@@ -136,7 +136,7 @@ func validateMinConfirmations(conf *OffchainConfig) error {
 	return nil
 }
 
-func validateGasLimitPerReport(conf *OffchainConfig) error {
+func defaultGasLimitPerReport(conf *OffchainConfig) error {
 	// defined as uint so cannot be < 0
 	if conf.GasLimitPerReport == 0 {
 		conf.GasLimitPerReport = 5_300_000
@@ -145,7 +145,7 @@ func validateGasLimitPerReport(conf *OffchainConfig) error {
 	return nil
 }
 
-func validateGasOverheadPerUpkeep(conf *OffchainConfig) error {
+func defaultGasOverheadPerUpkeep(conf *OffchainConfig) error {
 	// defined as uint so cannot be < 0
 	if conf.GasOverheadPerUpkeep == 0 {
 		conf.GasOverheadPerUpkeep = 300_000
@@ -154,7 +154,7 @@ func validateGasOverheadPerUpkeep(conf *OffchainConfig) error {
 	return nil
 }
 
-func validateMaxUpkeepBatchSize(conf *OffchainConfig) error {
+func defaultMaxUpkeepBatchSize(conf *OffchainConfig) error {
 	if conf.MaxUpkeepBatchSize <= 0 {
 		conf.MaxUpkeepBatchSize = 1
 	}

--- a/pkg/v3/config/config.go
+++ b/pkg/v3/config/config.go
@@ -26,7 +26,7 @@ var (
 	// each field should be validated and default values set, if any
 	// if a value is invalid, return an error but don't override it with the
 	// default
-	validators = []validator{
+	defaults = []defaulter{
 		defaultPerformLockoutWindow,
 		defaultTargetProbability,
 		defaultTargetInRounds,
@@ -91,8 +91,8 @@ func DecodeOffchainConfig(b []byte) (OffchainConfig, error) {
 		return config, err
 	}
 
-	// go through all validators and return an error immediately if encountered
-	for _, v := range validators {
+	// go through all defaults and return an error immediately if encountered
+	for _, v := range defaults {
 		if err := v(&config); err != nil {
 			return config, err
 		}
@@ -101,7 +101,7 @@ func DecodeOffchainConfig(b []byte) (OffchainConfig, error) {
 	return config, nil
 }
 
-type validator func(*OffchainConfig) error
+type defaulter func(*OffchainConfig) error
 
 func defaultPerformLockoutWindow(conf *OffchainConfig) error {
 	if conf.PerformLockoutWindow <= 0 {

--- a/pkg/v3/config/config_test.go
+++ b/pkg/v3/config/config_test.go
@@ -138,14 +138,14 @@ func TestDecodeOffchainConfig(t *testing.T) {
 }
 
 func TestDecodeOffchainConfig_validator(t *testing.T) {
-	oldValidators := validators
-	validators = []validator{
+	oldValidators := defaults
+	defaults = []defaulter{
 		func(config *OffchainConfig) error {
 			return errors.New("validation failure")
 		},
 	}
 	defer func() {
-		validators = oldValidators
+		defaults = oldValidators
 	}()
 
 	_, err := DecodeOffchainConfig([]byte(`

--- a/pkg/v3/config/config_test.go
+++ b/pkg/v3/config/config_test.go
@@ -3,7 +3,6 @@ package config
 import (
 	"testing"
 
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -135,32 +134,4 @@ func TestDecodeOffchainConfig(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestDecodeOffchainConfig_validator(t *testing.T) {
-	oldValidators := defaults
-	defaults = []defaulter{
-		func(config *OffchainConfig) error {
-			return errors.New("validation failure")
-		},
-	}
-	defer func() {
-		defaults = oldValidators
-	}()
-
-	_, err := DecodeOffchainConfig([]byte(`
-		{
-			"performLockoutWindow": 1000,
-			"targetProbability": "0.999",
-			"targetInRounds": 1,
-			"samplingJobDuration": 1000,
-			"minConfirmations": 10,
-			"gasLimitPerReport": 10,
-			"gasOverheadPerUpkeep": 100,
-			"maxUpkeepBatchSize": 100,
-			"reportBlockLag": 100,
-			"mercuryLookup": true
-		}
-	`))
-	assert.Error(t, err)
 }


### PR DESCRIPTION
The old validators we had were unnecessary in that they allowed for an error to be returned, but never returned an error. Instead of having a validator type, and a list of validators that we apply one at a time, I've removed these types and instead consolidated the functionality into a single `ensureMinimumDefaults` function. 

Ideally I think this function should live on the config object itself, but we don't have a pointer to the config, and I don't like using `&` on copies, so I'm just keeping how we call the function as-is.