### PR TITLE
Ratio Returns Zero in Rounding

### DIFF
--- a/pkg/v3/plugin/factory.go
+++ b/pkg/v3/plugin/factory.go
@@ -151,8 +151,17 @@ func sampleFromProbability(rounds, nodes int, probability float32) (sampleRatio,
 type sampleRatio float32
 
 func (r sampleRatio) OfInt(count int) int {
+	if count == 0 {
+		return 0
+	}
+
 	// rounds the result using basic rounding op
-	return int(math.Round(float64(r) * float64(count)))
+	value := math.Round(float64(r) * float64(count))
+	if value < 1.0 {
+		return 1
+	}
+
+	return int(value)
 }
 
 func (r sampleRatio) String() string {


### PR DESCRIPTION
For selecting sample sizes, the goal is to split the work between multiple nodes and mostly has been focused on larger numbers when sampling. In the case of a sample ratio less than 0.5 and a count of 1, the value returned would be zero.

There aren't any cases where a zero value would be desireable and at the minimum of 1 upkeep, all nodes could check the same upkeep without putting strain on any node.

The fix for now is to return only values greater than zero. In the case of a value being rounded down to zero, return 1 unless the incoming count is zero.