### PR TITLE
Consider perform lockout window as milliseconds

### DIFF
--- a/pkg/v2/coordinator/factory.go
+++ b/pkg/v2/coordinator/factory.go
@@ -20,7 +20,7 @@ type CoordinatorFactory struct {
 // config. The new coordinator is not automatically started.
 func (f *CoordinatorFactory) NewCoordinator(c config.OffchainConfig) (ocr2keepers.Coordinator, error) {
 	return NewReportCoordinator(
-		time.Duration(c.PerformLockoutWindow),
+		time.Duration(c.PerformLockoutWindow)*time.Millisecond,
 		f.CacheClean,
 		f.Logs,
 		c.MinConfirmations,


### PR DESCRIPTION
unfortunately this bug was introduced in https://github.com/smartcontractkit/ocr2keepers/pull/131/files#diff-9704faa00aeb2d10f038f68b042ee9b0484bfc10d277c2823b3e02bc52292d64 (moving from `internal/keepers/factory.go` line 120 to `pkg/coordinator/factory.go` line 23