### PR TITLE
Improve coordination of conditionals on successive performs

### DIFF
--- a/pkg/v3/coordinator/coordinator.go
+++ b/pkg/v3/coordinator/coordinator.go
@@ -146,8 +146,8 @@ func (c *coordinator) ShouldProcess(workID string, upkeepID ocr2keepers.UpkeepId
 			case ocr2keepers.ConditionTrigger:
 				switch v.transmitType {
 				case ocr2keepers.PerformEvent:
-					// For conditionals, a particular workID should only be checked after its last perform
-					return trigger.BlockNumber > v.transmitBlockNumber
+					// For conditionals, a particular workID should only be checked after or on its last perform block
+					return trigger.BlockNumber >= v.transmitBlockNumber
 				default:
 					// There was an attempt to check this workID, but it failed, so should be processed again
 					return true

--- a/pkg/v3/stores/proposal_queue.go
+++ b/pkg/v3/stores/proposal_queue.go
@@ -48,7 +48,7 @@ func (pq *proposalQueue) Enqueue(newProposals ...ocr2keepers.CoordinatedBlockPro
 
 	for _, p := range newProposals {
 		if existing, ok := pq.records[p.WorkID]; ok {
-			if p.Trigger.BlockNumber <= existing.proposal.Trigger.BlockNumber {
+			if existing.proposal.Trigger.BlockNumber >= p.Trigger.BlockNumber {
 				// If existing proposal is on newer or equal check block then skip this proposal
 				continue
 			}

--- a/pkg/v3/stores/proposal_queue.go
+++ b/pkg/v3/stores/proposal_queue.go
@@ -49,7 +49,7 @@ func (pq *proposalQueue) Enqueue(newProposals ...ocr2keepers.CoordinatedBlockPro
 	for _, p := range newProposals {
 		if existing, ok := pq.records[p.WorkID]; ok {
 			if existing.proposal.Trigger.BlockNumber >= p.Trigger.BlockNumber {
-				// If existing proposal is on newer or equal check block then skip this proposal
+				// Only if existing proposal is on newer or equal check block then skip this proposal
 				continue
 			}
 		}

--- a/pkg/v3/stores/proposal_queue.go
+++ b/pkg/v3/stores/proposal_queue.go
@@ -47,8 +47,11 @@ func (pq *proposalQueue) Enqueue(newProposals ...ocr2keepers.CoordinatedBlockPro
 	defer pq.lock.Unlock()
 
 	for _, p := range newProposals {
-		if _, ok := pq.records[p.WorkID]; ok {
-			continue
+		if existing, ok := pq.records[p.WorkID]; ok {
+			if p.Trigger.BlockNumber <= existing.proposal.Trigger.BlockNumber {
+				// If existing proposal is on newer or equal check block then skip this proposal
+				continue
+			}
 		}
 		pq.records[p.WorkID] = proposalQueueRecord{
 			proposal:  p,


### PR DESCRIPTION
1. In coordinated queue, if record already exists, allow adding a new proposal on a higher check block. This can happen in case of conditionals which perform very quickly and get coordinated on a new block after previous perform before expiry timeout

2. In coordinator, for conditonals, allow proposal to be processed on the same block as last perform. this matches the contract which allows check block to be equal last perform https://github.com/smartcontractkit/chainlink/blob/develop/contracts/src/v0.8/automation/v2_1/KeeperRegistryBase2_1.sol#L771-L775 (only says stale report if `trigger.blockNum < transmitInfo.upkeep.lastPerformedBlockNumber`)