### PR TITLE
[DO NOT MERGE] Proposal for Upkeep State Telemetry

### DIFF
--- a/cmd/simulator/main.go
+++ b/cmd/simulator/main.go
@@ -79,6 +79,7 @@ func main() {
 			outputs.RPCCollector,
 			outputs.LogCollector,
 			outputs.EventCollector,
+			outputs.StatusCollector,
 		},
 		Logger: outputs.SimulationLog,
 	}

--- a/pkg/v3/flows/conditional_test.go
+++ b/pkg/v3/flows/conditional_test.go
@@ -14,6 +14,7 @@ import (
 	ocr2keepersv3 "github.com/smartcontractkit/chainlink-automation/pkg/v3"
 	"github.com/smartcontractkit/chainlink-automation/pkg/v3/service"
 	"github.com/smartcontractkit/chainlink-automation/pkg/v3/stores"
+	"github.com/smartcontractkit/chainlink-automation/pkg/v3/telemetry"
 	ocr2keepers "github.com/smartcontractkit/chainlink-automation/pkg/v3/types"
 	"github.com/smartcontractkit/chainlink-automation/pkg/v3/types/mocks"
 )
@@ -28,7 +29,7 @@ func TestConditionalFinalization(t *testing.T) {
 		"0x2",
 	}
 
-	logger := log.New(io.Discard, "", log.LstdFlags)
+	logger := telemetry.NewTelemetryLogger(log.New(io.Discard, "", log.LstdFlags), io.Discard)
 
 	times := 3
 
@@ -121,7 +122,7 @@ func TestSamplingProposal(t *testing.T) {
 		"0x3",
 	}
 
-	logger := log.New(io.Discard, "", log.LstdFlags)
+	logger := telemetry.NewTelemetryLogger(log.New(io.Discard, "", log.LstdFlags), io.Discard)
 
 	runner := new(mocks.MockRunnable)
 	mStore := new(mocks.MockMetadataStore)

--- a/pkg/v3/flows/factory.go
+++ b/pkg/v3/flows/factory.go
@@ -1,11 +1,11 @@
 package flows
 
 import (
-	"log"
 	"time"
 
 	ocr2keepersv3 "github.com/smartcontractkit/chainlink-automation/pkg/v3"
 	"github.com/smartcontractkit/chainlink-automation/pkg/v3/service"
+	"github.com/smartcontractkit/chainlink-automation/pkg/v3/telemetry"
 	ocr2keepers "github.com/smartcontractkit/chainlink-automation/pkg/v3/types"
 )
 
@@ -21,7 +21,7 @@ func ConditionalTriggerFlows(
 	proposalQ ocr2keepers.ProposalQueue,
 	retryQ ocr2keepers.RetryQueue,
 	stateUpdater ocr2keepers.UpkeepStateUpdater,
-	logger *log.Logger,
+	logger *telemetry.Logger,
 ) []service.Recoverable {
 	preprocessors := []ocr2keepersv3.PreProcessor[ocr2keepers.UpkeepPayload]{coord}
 
@@ -49,7 +49,7 @@ func LogTriggerFlows(
 	retryQ ocr2keepers.RetryQueue,
 	proposals ocr2keepers.ProposalQueue,
 	stateUpdater ocr2keepers.UpkeepStateUpdater,
-	logger *log.Logger,
+	logger *telemetry.Logger,
 ) []service.Recoverable {
 	// all flows use the same preprocessor based on the coordinator
 	// each flow can add preprocessors to this provided slice

--- a/pkg/v3/flows/factory_test.go
+++ b/pkg/v3/flows/factory_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/smartcontractkit/chainlink-automation/pkg/v3/telemetry"
 	ocr2keepers "github.com/smartcontractkit/chainlink-automation/pkg/v3/types"
 )
 
@@ -33,7 +34,7 @@ func TestConditionalTriggerFlows(t *testing.T) {
 		nil,
 		nil,
 		nil,
-		log.New(io.Discard, "", 0),
+		telemetry.NewTelemetryLogger(log.New(io.Discard, "", 0), io.Discard),
 	)
 	assert.Equal(t, 2, len(flows))
 }
@@ -57,7 +58,7 @@ func TestLogTriggerFlows(t *testing.T) {
 		nil,
 		nil,
 		nil,
-		log.New(io.Discard, "", 0),
+		telemetry.NewTelemetryLogger(log.New(io.Discard, "", 0), io.Discard),
 	)
 	assert.Equal(t, 3, len(flows))
 }

--- a/pkg/v3/flows/logtrigger_test.go
+++ b/pkg/v3/flows/logtrigger_test.go
@@ -14,12 +14,13 @@ import (
 	ocr2keepersv3 "github.com/smartcontractkit/chainlink-automation/pkg/v3"
 	"github.com/smartcontractkit/chainlink-automation/pkg/v3/service"
 	"github.com/smartcontractkit/chainlink-automation/pkg/v3/stores"
+	"github.com/smartcontractkit/chainlink-automation/pkg/v3/telemetry"
 	ocr2keepers "github.com/smartcontractkit/chainlink-automation/pkg/v3/types"
 	"github.com/smartcontractkit/chainlink-automation/pkg/v3/types/mocks"
 )
 
 func TestLogTriggerFlow(t *testing.T) {
-	logger := log.New(io.Discard, "", log.LstdFlags)
+	logger := telemetry.NewTelemetryLogger(log.New(io.Discard, "", log.LstdFlags), io.Discard)
 
 	times := 2
 

--- a/pkg/v3/flows/recovery.go
+++ b/pkg/v3/flows/recovery.go
@@ -34,12 +34,12 @@ func newFinalRecoveryFlow(
 	proposalQ ocr2keepers.ProposalQueue,
 	builder ocr2keepers.PayloadBuilder,
 	stateUpdater ocr2keepers.UpkeepStateUpdater,
-	logger *log.Logger,
+	logger *telemetry.Logger,
 ) service.Recoverable {
 	post := postprocessors.NewCombinedPostprocessor(
-		postprocessors.NewEligiblePostProcessor(resultStore, telemetry.WrapLogger(logger, "recovery-final-eligible-postprocessor")),
-		postprocessors.NewRetryablePostProcessor(retryQ, telemetry.WrapLogger(logger, "recovery-final-retryable-postprocessor")),
-		postprocessors.NewIneligiblePostProcessor(stateUpdater, telemetry.WrapLogger(logger, "retry-ineligible-postprocessor")),
+		postprocessors.NewEligiblePostProcessor(resultStore, telemetry.WrapTelemetryLogger(logger, "recovery-final-eligible-postprocessor")),
+		postprocessors.NewRetryablePostProcessor(retryQ, telemetry.WrapTelemetryLogger(logger, "recovery-final-retryable-postprocessor")),
+		postprocessors.NewIneligiblePostProcessor(stateUpdater, telemetry.WrapTelemetryLogger(logger, "retry-ineligible-postprocessor")),
 	)
 	// create observer that only pushes results to result stores. everything at
 	// this point can be dropped. this process is only responsible for running
@@ -67,7 +67,7 @@ func newFinalRecoveryFlow(
 
 // coordinatedProposalsTick is used to push proposals from the proposal queue to some observer
 type coordinatedProposalsTick struct {
-	logger    *log.Logger
+	logger    *telemetry.Logger
 	builder   ocr2keepers.PayloadBuilder
 	q         ocr2keepers.ProposalQueue
 	utype     ocr2keepers.UpkeepType
@@ -109,7 +109,7 @@ func newRecoveryProposalFlow(
 	recoverableProvider ocr2keepers.RecoverableProvider,
 	recoveryInterval time.Duration,
 	stateUpdater ocr2keepers.UpkeepStateUpdater,
-	logger *log.Logger,
+	logger *telemetry.Logger,
 ) service.Recoverable {
 	preProcessors = append(preProcessors, preprocessors.NewProposalFilterer(metadataStore, ocr2keepers.LogTrigger))
 	postprocessors := postprocessors.NewCombinedPostprocessor(
@@ -132,7 +132,7 @@ func newRecoveryProposalFlow(
 
 type logRecoveryTick struct {
 	logRecoverer ocr2keepers.RecoverableProvider
-	logger       *log.Logger
+	logger       *telemetry.Logger
 }
 
 func (et logRecoveryTick) Value(ctx context.Context) ([]ocr2keepers.UpkeepPayload, error) {

--- a/pkg/v3/flows/recovery_test.go
+++ b/pkg/v3/flows/recovery_test.go
@@ -14,6 +14,7 @@ import (
 	ocr2keepersv3 "github.com/smartcontractkit/chainlink-automation/pkg/v3"
 	"github.com/smartcontractkit/chainlink-automation/pkg/v3/service"
 	"github.com/smartcontractkit/chainlink-automation/pkg/v3/stores"
+	"github.com/smartcontractkit/chainlink-automation/pkg/v3/telemetry"
 	ocr2keepers "github.com/smartcontractkit/chainlink-automation/pkg/v3/types"
 	"github.com/smartcontractkit/chainlink-automation/pkg/v3/types/mocks"
 )
@@ -28,7 +29,7 @@ func TestRecoveryFinalization(t *testing.T) {
 		"0x2",
 	}
 
-	logger := log.New(io.Discard, "", log.LstdFlags)
+	logger := telemetry.NewTelemetryLogger(log.New(io.Discard, "", log.LstdFlags), io.Discard)
 
 	times := 3
 
@@ -123,7 +124,7 @@ func TestRecoveryProposal(t *testing.T) {
 		"0x3",
 	}
 
-	logger := log.New(io.Discard, "", log.LstdFlags)
+	logger := telemetry.NewTelemetryLogger(log.New(io.Discard, "", log.LstdFlags), io.Discard)
 
 	runner := new(mocks.MockRunnable)
 	mStore := new(mocks.MockMetadataStore)

--- a/pkg/v3/flows/retry.go
+++ b/pkg/v3/flows/retry.go
@@ -28,13 +28,13 @@ func NewRetryFlow(
 	retryQ ocr2keepers.RetryQueue,
 	retryTickerInterval time.Duration,
 	stateUpdater ocr2keepers.UpkeepStateUpdater,
-	logger *log.Logger,
+	logger *telemetry.Logger,
 ) service.Recoverable {
 	preprocessors := []ocr2keepersv3.PreProcessor[ocr2keepers.UpkeepPayload]{coord}
 	post := postprocessors.NewCombinedPostprocessor(
-		postprocessors.NewEligiblePostProcessor(resultStore, telemetry.WrapLogger(logger, "retry-eligible-postprocessor")),
-		postprocessors.NewRetryablePostProcessor(retryQ, telemetry.WrapLogger(logger, "retry-retryable-postprocessor")),
-		postprocessors.NewIneligiblePostProcessor(stateUpdater, telemetry.WrapLogger(logger, "retry-ineligible-postprocessor")),
+		postprocessors.NewEligiblePostProcessor(resultStore, telemetry.WrapTelemetryLogger(logger, "retry-eligible-postprocessor")),
+		postprocessors.NewRetryablePostProcessor(retryQ, telemetry.WrapTelemetryLogger(logger, "retry-retryable-postprocessor")),
+		postprocessors.NewIneligiblePostProcessor(stateUpdater, telemetry.WrapTelemetryLogger(logger, "retry-ineligible-postprocessor")),
 	)
 
 	obs := ocr2keepersv3.NewRunnableObserver(
@@ -53,7 +53,7 @@ func NewRetryFlow(
 }
 
 type retryTick struct {
-	logger    *log.Logger
+	logger    *telemetry.Logger
 	q         ocr2keepers.RetryQueue
 	batchSize int
 }

--- a/pkg/v3/flows/retry_test.go
+++ b/pkg/v3/flows/retry_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink-automation/pkg/v3/service"
 	"github.com/smartcontractkit/chainlink-automation/pkg/v3/stores"
+	"github.com/smartcontractkit/chainlink-automation/pkg/v3/telemetry"
 	ocr2keepers "github.com/smartcontractkit/chainlink-automation/pkg/v3/types"
 	"github.com/smartcontractkit/chainlink-automation/pkg/v3/types/mocks"
 
@@ -18,7 +19,7 @@ import (
 )
 
 func TestRetryFlow(t *testing.T) {
-	logger := log.New(io.Discard, "", log.LstdFlags)
+	logger := telemetry.NewTelemetryLogger(log.New(io.Discard, "", log.LstdFlags), io.Discard)
 
 	times := 3
 

--- a/pkg/v3/plugin/coordinated_block_proposals_test.go
+++ b/pkg/v3/plugin/coordinated_block_proposals_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	ocr2keepers "github.com/smartcontractkit/chainlink-automation/pkg/v3"
+	"github.com/smartcontractkit/chainlink-automation/pkg/v3/telemetry"
 	"github.com/smartcontractkit/chainlink-automation/pkg/v3/types"
 )
 
@@ -336,7 +337,7 @@ func Test_newCoordinatedBlockProposals_add(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			proposals := newCoordinatedBlockProposals(tc.quorumBlockthreshold, 2, 3, [16]byte{1}, log.New(io.Discard, "", 1))
+			proposals := newCoordinatedBlockProposals(tc.quorumBlockthreshold, 2, 3, [16]byte{1}, telemetry.NewTelemetryLogger(log.New(io.Discard, "", 1), io.Discard))
 			for _, ao := range tc.observations {
 				proposals.add(ao)
 			}
@@ -511,7 +512,7 @@ func Test_performableExists(t *testing.T) {
 
 func Test_newCoordinatedBlockProposals_set(t *testing.T) {
 	t.Run("calling set on an empty outcome with an empty previous outcome updates the outcome based on the internal state", func(t *testing.T) {
-		proposals := newCoordinatedBlockProposals(1, 2, 3, [16]byte{1}, log.New(io.Discard, "", 1))
+		proposals := newCoordinatedBlockProposals(1, 2, 3, [16]byte{1}, telemetry.NewTelemetryLogger(log.New(io.Discard, "", 1), io.Discard))
 
 		observations := []ocr2keepers.AutomationObservation{
 			{
@@ -597,7 +598,7 @@ func Test_newCoordinatedBlockProposals_set(t *testing.T) {
 	})
 
 	t.Run("new proposals that already exist on the surfaced proposals and agreed performables of the previous outcome are not re-added", func(t *testing.T) {
-		proposals := newCoordinatedBlockProposals(1, 2, 3, [16]byte{1}, log.New(io.Discard, "", 1))
+		proposals := newCoordinatedBlockProposals(1, 2, 3, [16]byte{1}, telemetry.NewTelemetryLogger(log.New(io.Discard, "", 1), io.Discard))
 
 		observations := []ocr2keepers.AutomationObservation{
 			{
@@ -705,7 +706,7 @@ func Test_newCoordinatedBlockProposals_set(t *testing.T) {
 	})
 
 	t.Run("when the number of surfaced proposals in the previous outcome equals or exceeds the round history limit, the number of surfaced proposals is truncated to the limit", func(t *testing.T) {
-		proposals := newCoordinatedBlockProposals(1, 1, 3, [16]byte{1}, log.New(io.Discard, "", 1))
+		proposals := newCoordinatedBlockProposals(1, 1, 3, [16]byte{1}, telemetry.NewTelemetryLogger(log.New(io.Discard, "", 1), io.Discard))
 
 		observations := []ocr2keepers.AutomationObservation{
 			{
@@ -821,7 +822,7 @@ func Test_newCoordinatedBlockProposals_set(t *testing.T) {
 	})
 
 	t.Run("when the number of latest proposals exceeds the per round limit, the number of surfaced proposals is truncated to the limit", func(t *testing.T) {
-		proposals := newCoordinatedBlockProposals(1, 1, 1, [16]byte{1}, log.New(io.Discard, "", 1))
+		proposals := newCoordinatedBlockProposals(1, 1, 1, [16]byte{1}, telemetry.NewTelemetryLogger(log.New(io.Discard, "", 1), io.Discard))
 
 		observations := []ocr2keepers.AutomationObservation{
 			{
@@ -925,7 +926,7 @@ func Test_newCoordinatedBlockProposals_set(t *testing.T) {
 	})
 
 	t.Run("when the quorum block cannot be fetched, we return without adding new proposals", func(t *testing.T) {
-		proposals := newCoordinatedBlockProposals(3, 1, 3, [16]byte{1}, log.New(io.Discard, "", 1))
+		proposals := newCoordinatedBlockProposals(3, 1, 3, [16]byte{1}, telemetry.NewTelemetryLogger(log.New(io.Discard, "", 1), io.Discard))
 
 		observations := []ocr2keepers.AutomationObservation{
 			{

--- a/pkg/v3/plugin/delegate.go
+++ b/pkg/v3/plugin/delegate.go
@@ -3,6 +3,7 @@ package plugin
 import (
 	"context"
 	"fmt"
+	"io"
 	"log"
 	"time"
 
@@ -98,6 +99,8 @@ type DelegateConfig struct {
 	// workers or slower RPC responses will cause this queue to build up.
 	// Adding new items to the queue will block if the queue becomes full.
 	ServiceQueueLength int
+
+	TelemetryWriter io.Writer
 }
 
 // Delegate is a container struct for an Oracle plugin. This struct provides
@@ -142,7 +145,7 @@ func NewDelegate(c DelegateConfig) (*Delegate, error) {
 	// the log wrapper is to be able to use a log.Logger everywhere instead of
 	// a variety of logger types. all logs write to the Debug method.
 	wrapper := &logWriter{l: c.Logger}
-	l := log.New(wrapper, fmt.Sprintf("[%s] ", telemetry.ServiceName), log.Lshortfile)
+	l := telemetry.NewTelemetryLogger(log.New(wrapper, fmt.Sprintf("[%s] ", telemetry.ServiceName), log.Lshortfile), c.TelemetryWriter)
 
 	l.Printf("creating oracle with reporting factory config: %+v", conf)
 
@@ -187,7 +190,7 @@ func NewDelegate(c DelegateConfig) (*Delegate, error) {
 
 	return &Delegate{
 		keeper: keeper,
-		logger: l,
+		logger: l.GetLogger(),
 	}, nil
 }
 

--- a/pkg/v3/plugin/factory.go
+++ b/pkg/v3/plugin/factory.go
@@ -2,7 +2,6 @@ package plugin
 
 import (
 	"fmt"
-	"log"
 	"math"
 	"math/cmplx"
 	"strconv"
@@ -12,6 +11,7 @@ import (
 	ocr2keepers "github.com/smartcontractkit/chainlink-automation/pkg/v3"
 	"github.com/smartcontractkit/chainlink-automation/pkg/v3/config"
 	"github.com/smartcontractkit/chainlink-automation/pkg/v3/runner"
+	"github.com/smartcontractkit/chainlink-automation/pkg/v3/telemetry"
 	"github.com/smartcontractkit/chainlink-automation/pkg/v3/types"
 )
 
@@ -28,7 +28,7 @@ type pluginFactory struct {
 	upkeepTypeGetter   types.UpkeepTypeGetter
 	workIDGenerator    types.WorkIDGenerator
 	upkeepStateUpdater types.UpkeepStateUpdater
-	logger             *log.Logger
+	logger             *telemetry.Logger
 }
 
 func NewReportingPluginFactory(
@@ -44,7 +44,7 @@ func NewReportingPluginFactory(
 	upkeepTypeGetter types.UpkeepTypeGetter,
 	workIDGenerator types.WorkIDGenerator,
 	upkeepStateUpdater types.UpkeepStateUpdater,
-	logger *log.Logger,
+	logger *telemetry.Logger,
 ) ocr3types.ReportingPluginFactory[AutomationReportInfo] {
 	return &pluginFactory{
 		logProvider:        logProvider,

--- a/pkg/v3/plugin/hooks/add_block_history.go
+++ b/pkg/v3/plugin/hooks/add_block_history.go
@@ -1,9 +1,6 @@
 package hooks
 
 import (
-	"fmt"
-	"log"
-
 	ocr2keepersv3 "github.com/smartcontractkit/chainlink-automation/pkg/v3"
 	"github.com/smartcontractkit/chainlink-automation/pkg/v3/telemetry"
 	ocr2keepers "github.com/smartcontractkit/chainlink-automation/pkg/v3/types"
@@ -11,13 +8,14 @@ import (
 
 type AddBlockHistoryHook struct {
 	metadata ocr2keepers.MetadataStore
-	logger   *log.Logger
+	logger   *telemetry.Logger
 }
 
-func NewAddBlockHistoryHook(ms ocr2keepers.MetadataStore, logger *log.Logger) AddBlockHistoryHook {
+func NewAddBlockHistoryHook(ms ocr2keepers.MetadataStore, logger *telemetry.Logger) AddBlockHistoryHook {
 	return AddBlockHistoryHook{
 		metadata: ms,
-		logger:   log.New(logger.Writer(), fmt.Sprintf("[%s | build hook:add-block-history]", telemetry.ServiceName), telemetry.LogPkgStdFlags)}
+		logger:   telemetry.WrapTelemetryLogger(logger, "build hook:add-block-history"),
+	}
 }
 
 func (h *AddBlockHistoryHook) RunHook(obs *ocr2keepersv3.AutomationObservation, limit int) {

--- a/pkg/v3/plugin/hooks/add_block_history_test.go
+++ b/pkg/v3/plugin/hooks/add_block_history_test.go
@@ -2,12 +2,14 @@ package hooks
 
 import (
 	"bytes"
+	"io"
 	"log"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
 	ocr2keepersv3 "github.com/smartcontractkit/chainlink-automation/pkg/v3"
+	"github.com/smartcontractkit/chainlink-automation/pkg/v3/telemetry"
 	"github.com/smartcontractkit/chainlink-automation/pkg/v3/types"
 	"github.com/smartcontractkit/chainlink-automation/pkg/v3/types/mocks"
 )
@@ -71,7 +73,7 @@ func TestAddBlockHistoryHook_RunHook(t *testing.T) {
 
 			// Prepare logger
 			var logBuf bytes.Buffer
-			logger := log.New(&logBuf, "", 0)
+			logger := telemetry.NewTelemetryLogger(log.New(&logBuf, "", 0), io.Discard)
 
 			// Create the hook with mock MetadataStore and logger
 			addBlockHistoryHook := NewAddBlockHistoryHook(mockMetadataStore, logger)

--- a/pkg/v3/plugin/hooks/add_conditional_proposals_test.go
+++ b/pkg/v3/plugin/hooks/add_conditional_proposals_test.go
@@ -3,12 +3,14 @@ package hooks
 import (
 	"bytes"
 	"errors"
+	"io"
 	"log"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
 	ocr2keepers "github.com/smartcontractkit/chainlink-automation/pkg/v3"
+	"github.com/smartcontractkit/chainlink-automation/pkg/v3/telemetry"
 	"github.com/smartcontractkit/chainlink-automation/pkg/v3/types"
 )
 
@@ -155,7 +157,8 @@ func TestAddConditionalSamplesHook_RunHook(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			var logBuf bytes.Buffer
-			logger := log.New(&logBuf, "", 0)
+			logger := telemetry.NewTelemetryLogger(log.New(&logBuf, "", 0), io.Discard)
+
 			processor := NewAddConditionalProposalsHook(tc.metadata, tc.coordinator, logger)
 			observation := &ocr2keepers.AutomationObservation{
 				UpkeepProposals: tc.proposals,

--- a/pkg/v3/plugin/hooks/add_from_staging_test.go
+++ b/pkg/v3/plugin/hooks/add_from_staging_test.go
@@ -3,6 +3,7 @@ package hooks
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"log"
 	"testing"
 
@@ -10,6 +11,7 @@ import (
 	"github.com/stretchr/testify/mock"
 
 	ocr2keepersv3 "github.com/smartcontractkit/chainlink-automation/pkg/v3"
+	"github.com/smartcontractkit/chainlink-automation/pkg/v3/telemetry"
 	"github.com/smartcontractkit/chainlink-automation/pkg/v3/types"
 	"github.com/smartcontractkit/chainlink-automation/pkg/v3/types/mocks"
 )
@@ -153,7 +155,7 @@ func TestAddFromStagingHook_RunHook(t *testing.T) {
 
 			// Prepare logger
 			var logBuf bytes.Buffer
-			logger := log.New(&logBuf, "", 0)
+			logger := telemetry.NewTelemetryLogger(log.New(&logBuf, "", 0), io.Discard)
 
 			// Prepare observation and random source
 			obs := &tt.initialObservation
@@ -211,7 +213,8 @@ func TestAddFromStagingHook_RunHook_Limits(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			mockResultStore, mockCoordinator := getMocks(tt.n)
 			var logBuf bytes.Buffer
-			logger := log.New(&logBuf, "", 0)
+			logger := telemetry.NewTelemetryLogger(log.New(&logBuf, "", 0), io.Discard)
+
 			addFromStagingHook := NewAddFromStagingHook(mockResultStore, mockCoordinator, logger)
 
 			rSrc := [16]byte{1, 1, 2, 2, 3, 3, 4, 4}

--- a/pkg/v3/plugin/hooks/add_log_proposals_test.go
+++ b/pkg/v3/plugin/hooks/add_log_proposals_test.go
@@ -3,12 +3,14 @@ package hooks
 import (
 	"bytes"
 	"errors"
+	"io"
 	"log"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
 	ocr2keepers "github.com/smartcontractkit/chainlink-automation/pkg/v3"
+	"github.com/smartcontractkit/chainlink-automation/pkg/v3/telemetry"
 	"github.com/smartcontractkit/chainlink-automation/pkg/v3/types"
 )
 
@@ -133,7 +135,8 @@ func TestAddLogRecoveryProposalsHook_RunHook(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			var logBuf bytes.Buffer
-			logger := log.New(&logBuf, "", 0)
+			logger := telemetry.NewTelemetryLogger(log.New(&logBuf, "", 0), io.Discard)
+
 			processor := NewAddLogProposalsHook(tc.metadata, tc.coordinator, logger)
 			observation := &ocr2keepers.AutomationObservation{
 				UpkeepProposals: tc.proposals,

--- a/pkg/v3/plugin/hooks/add_to_proposalq.go
+++ b/pkg/v3/plugin/hooks/add_to_proposalq.go
@@ -1,24 +1,21 @@
 package hooks
 
 import (
-	"fmt"
-	"log"
-
 	ocr2keepersv3 "github.com/smartcontractkit/chainlink-automation/pkg/v3"
 	"github.com/smartcontractkit/chainlink-automation/pkg/v3/telemetry"
 	ocr2keepers "github.com/smartcontractkit/chainlink-automation/pkg/v3/types"
 )
 
-func NewAddToProposalQHook(proposalQ ocr2keepers.ProposalQueue, logger *log.Logger) AddToProposalQHook {
+func NewAddToProposalQHook(proposalQ ocr2keepers.ProposalQueue, logger *telemetry.Logger) AddToProposalQHook {
 	return AddToProposalQHook{
 		proposalQ: proposalQ,
-		logger:    log.New(logger.Writer(), fmt.Sprintf("[%s | pre-build hook:add-to-proposalq]", telemetry.ServiceName), telemetry.LogPkgStdFlags),
+		logger:    telemetry.WrapTelemetryLogger(logger, "pre-build hook:add-to-proposalq"),
 	}
 }
 
 type AddToProposalQHook struct {
 	proposalQ ocr2keepers.ProposalQueue
-	logger    *log.Logger
+	logger    *telemetry.Logger
 }
 
 func (hook *AddToProposalQHook) RunHook(outcome ocr2keepersv3.AutomationOutcome) {

--- a/pkg/v3/plugin/hooks/add_to_proposalq_test.go
+++ b/pkg/v3/plugin/hooks/add_to_proposalq_test.go
@@ -2,6 +2,7 @@ package hooks
 
 import (
 	"bytes"
+	"io"
 	"log"
 	"testing"
 
@@ -9,6 +10,7 @@ import (
 
 	ocr2keepersv3 "github.com/smartcontractkit/chainlink-automation/pkg/v3"
 	"github.com/smartcontractkit/chainlink-automation/pkg/v3/stores"
+	"github.com/smartcontractkit/chainlink-automation/pkg/v3/telemetry"
 	"github.com/smartcontractkit/chainlink-automation/pkg/v3/types"
 )
 
@@ -61,7 +63,7 @@ func TestAddToProposalQHook_RunHook(t *testing.T) {
 
 			// Prepare mock logger
 			var logBuf bytes.Buffer
-			logger := log.New(&logBuf, "", 0)
+			logger := telemetry.NewTelemetryLogger(log.New(&logBuf, "", 0), io.Discard)
 
 			// Create the hook with the proposal queue and logger
 			addToProposalQHook := NewAddToProposalQHook(proposalQ, logger)

--- a/pkg/v3/plugin/hooks/remove_from_metadata.go
+++ b/pkg/v3/plugin/hooks/remove_from_metadata.go
@@ -1,24 +1,21 @@
 package hooks
 
 import (
-	"fmt"
-	"log"
-
 	ocr2keepersv3 "github.com/smartcontractkit/chainlink-automation/pkg/v3"
 	"github.com/smartcontractkit/chainlink-automation/pkg/v3/telemetry"
 	"github.com/smartcontractkit/chainlink-automation/pkg/v3/types"
 )
 
-func NewRemoveFromMetadataHook(ms types.MetadataStore, logger *log.Logger) RemoveFromMetadataHook {
+func NewRemoveFromMetadataHook(ms types.MetadataStore, logger *telemetry.Logger) RemoveFromMetadataHook {
 	return RemoveFromMetadataHook{
 		ms:     ms,
-		logger: log.New(logger.Writer(), fmt.Sprintf("[%s | pre-build hook:remove-from-metadata]", telemetry.ServiceName), telemetry.LogPkgStdFlags),
+		logger: telemetry.WrapTelemetryLogger(logger, "pre-build hook:remove-from-metadata"),
 	}
 }
 
 type RemoveFromMetadataHook struct {
 	ms     types.MetadataStore
-	logger *log.Logger
+	logger *telemetry.Logger
 }
 
 func (hook *RemoveFromMetadataHook) RunHook(outcome ocr2keepersv3.AutomationOutcome) {

--- a/pkg/v3/plugin/hooks/remove_from_metadata_test.go
+++ b/pkg/v3/plugin/hooks/remove_from_metadata_test.go
@@ -2,12 +2,14 @@ package hooks
 
 import (
 	"bytes"
+	"io"
 	"log"
 	"testing"
 
 	"github.com/stretchr/testify/mock"
 
 	ocr2keepersv3 "github.com/smartcontractkit/chainlink-automation/pkg/v3"
+	"github.com/smartcontractkit/chainlink-automation/pkg/v3/telemetry"
 	"github.com/smartcontractkit/chainlink-automation/pkg/v3/types"
 	"github.com/smartcontractkit/chainlink-automation/pkg/v3/types/mocks"
 )
@@ -59,7 +61,7 @@ func TestRemoveFromMetadataHook_RunHook(t *testing.T) {
 
 			// Prepare logger
 			var logBuf bytes.Buffer
-			logger := log.New(&logBuf, "", 0)
+			logger := telemetry.NewTelemetryLogger(log.New(&logBuf, "", 0), io.Discard)
 
 			// Create the hook with mock MetadataStore, mock UpkeepTypeGetter, and logger
 			removeFromMetadataHook := NewRemoveFromMetadataHook(mockMetadataStore, logger)

--- a/pkg/v3/plugin/hooks/remove_from_staging.go
+++ b/pkg/v3/plugin/hooks/remove_from_staging.go
@@ -1,24 +1,21 @@
 package hooks
 
 import (
-	"fmt"
-	"log"
-
 	ocr2keepersv3 "github.com/smartcontractkit/chainlink-automation/pkg/v3"
 	"github.com/smartcontractkit/chainlink-automation/pkg/v3/telemetry"
 	"github.com/smartcontractkit/chainlink-automation/pkg/v3/types"
 )
 
-func NewRemoveFromStagingHook(store types.ResultStore, logger *log.Logger) RemoveFromStagingHook {
+func NewRemoveFromStagingHook(store types.ResultStore, logger *telemetry.Logger) RemoveFromStagingHook {
 	return RemoveFromStagingHook{
 		store:  store,
-		logger: log.New(logger.Writer(), fmt.Sprintf("[%s | pre-build hook:remove-from-staging]", telemetry.ServiceName), telemetry.LogPkgStdFlags),
+		logger: telemetry.WrapTelemetryLogger(logger, "pre-build hook:remove-from-staging"),
 	}
 }
 
 type RemoveFromStagingHook struct {
 	store  types.ResultStore
-	logger *log.Logger
+	logger *telemetry.Logger
 }
 
 func (hook *RemoveFromStagingHook) RunHook(outcome ocr2keepersv3.AutomationOutcome) {

--- a/pkg/v3/plugin/hooks/remove_from_staging_test.go
+++ b/pkg/v3/plugin/hooks/remove_from_staging_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	ocr2keepersv3 "github.com/smartcontractkit/chainlink-automation/pkg/v3"
+	"github.com/smartcontractkit/chainlink-automation/pkg/v3/telemetry"
 	"github.com/smartcontractkit/chainlink-automation/pkg/v3/types"
 	ocr2keepers "github.com/smartcontractkit/chainlink-automation/pkg/v3/types"
 )
@@ -65,7 +66,7 @@ func TestRemoveFromStagingHook(t *testing.T) {
 
 			mr := &mockResultStore{}
 
-			r := NewRemoveFromStagingHook(mr, log.New(io.Discard, "", 0))
+			r := NewRemoveFromStagingHook(mr, telemetry.NewTelemetryLogger(log.New(io.Discard, "", 0), io.Discard))
 
 			r.RunHook(ob)
 			assert.Equal(t, len(ob.AgreedPerformables), len(mr.removedIDs))

--- a/pkg/v3/plugin/ocr3_test.go
+++ b/pkg/v3/plugin/ocr3_test.go
@@ -20,6 +20,7 @@ import (
 	ocr2keepers2 "github.com/smartcontractkit/chainlink-automation/pkg/v3"
 	"github.com/smartcontractkit/chainlink-automation/pkg/v3/plugin/hooks"
 	"github.com/smartcontractkit/chainlink-automation/pkg/v3/service"
+	"github.com/smartcontractkit/chainlink-automation/pkg/v3/telemetry"
 	ocr2keepers "github.com/smartcontractkit/chainlink-automation/pkg/v3/types"
 )
 
@@ -33,7 +34,7 @@ func TestOcr3Plugin_Query(t *testing.T) {
 func TestOcr3Plugin_Observation(t *testing.T) {
 	t.Run("first round processing, previous outcome will be nil, creates an observation with 2 performables, 2 proposals and 2 block history", func(t *testing.T) {
 		var logBuf bytes.Buffer
-		logger := log.New(&logBuf, "ocr3-test-observation", 0)
+		logger := telemetry.NewTelemetryLogger(log.New(&logBuf, "ocr3-test-observation", 0), io.Discard)
 
 		metadataStore := &mockMetadataStore{
 			GetBlockHistoryFn: func() ocr2keepers.BlockHistory {
@@ -101,7 +102,7 @@ func TestOcr3Plugin_Observation(t *testing.T) {
 
 	t.Run("first round processing, previous outcome will be nil, creates an observation with 3 performables, 2 upkeep proposals and 3 block history", func(t *testing.T) {
 		var logBuf bytes.Buffer
-		logger := log.New(&logBuf, "ocr3-test-observation", 0)
+		logger := telemetry.NewTelemetryLogger(log.New(&logBuf, "ocr3-test-observation", 0), io.Discard)
 
 		metadataStore := &mockMetadataStore{
 			GetBlockHistoryFn: func() ocr2keepers.BlockHistory {
@@ -176,7 +177,7 @@ func TestOcr3Plugin_Observation(t *testing.T) {
 
 	t.Run("first round processing, previous outcome will be nil, creates an observation with 3 performables, 0 upkeep proposals and 3 block history", func(t *testing.T) {
 		var logBuf bytes.Buffer
-		logger := log.New(&logBuf, "ocr3-test-observation", 0)
+		logger := telemetry.NewTelemetryLogger(log.New(&logBuf, "ocr3-test-observation", 0), io.Discard)
 
 		metadataStore := &mockMetadataStore{
 			GetBlockHistoryFn: func() ocr2keepers.BlockHistory {
@@ -248,7 +249,7 @@ func TestOcr3Plugin_Observation(t *testing.T) {
 
 	t.Run("ineligible check result returns an error", func(t *testing.T) {
 		var logBuf bytes.Buffer
-		logger := log.New(&logBuf, "ocr3-test-observation", 0)
+		logger := telemetry.NewTelemetryLogger(log.New(&logBuf, "ocr3-test-observation", 0), io.Discard)
 
 		metadataStore := &mockMetadataStore{
 			GetBlockHistoryFn: func() ocr2keepers.BlockHistory {
@@ -346,7 +347,7 @@ func TestOcr3Plugin_Observation(t *testing.T) {
 
 	t.Run("subsequent round processing, previous outcome will be non nil, creates an observation built an observation with 2 performables, 0 upkeep proposals and 3 block history", func(t *testing.T) {
 		var logBuf bytes.Buffer
-		logger := log.New(&logBuf, "ocr3-test-observation", 0)
+		logger := telemetry.NewTelemetryLogger(log.New(&logBuf, "ocr3-test-observation", 0), io.Discard)
 
 		metadataStore := &mockMetadataStore{
 			GetBlockHistoryFn: func() ocr2keepers.BlockHistory {
@@ -459,7 +460,7 @@ func TestOcr3Plugin_Observation(t *testing.T) {
 
 	t.Run("subsequent round processing, previous outcome will be non nil, filters results, creates an observation built an observation with 1 performables, 0 upkeep proposals and 3 block history", func(t *testing.T) {
 		var logBuf bytes.Buffer
-		logger := log.New(&logBuf, "ocr3-test-observation", 0)
+		logger := telemetry.NewTelemetryLogger(log.New(&logBuf, "ocr3-test-observation", 0), io.Discard)
 
 		metadataStore := &mockMetadataStore{
 			GetBlockHistoryFn: func() ocr2keepers.BlockHistory {
@@ -573,7 +574,7 @@ func TestOcr3Plugin_Observation(t *testing.T) {
 
 	t.Run("subsequent round processing, previous outcome will be non nil, when AddFromStagingHook errors, an error is returned", func(t *testing.T) {
 		var logBuf bytes.Buffer
-		logger := log.New(&logBuf, "ocr3-test-observation", 0)
+		logger := telemetry.NewTelemetryLogger(log.New(&logBuf, "ocr3-test-observation", 0), io.Discard)
 
 		metadataStore := &mockMetadataStore{
 			GetBlockHistoryFn: func() ocr2keepers.BlockHistory {
@@ -674,7 +675,7 @@ func TestOcr3Plugin_Observation(t *testing.T) {
 
 	t.Run("subsequent round processing, previous outcome will be non nil, when AddLogProposalsHook errors, an error is returned", func(t *testing.T) {
 		var logBuf bytes.Buffer
-		logger := log.New(&logBuf, "ocr3-test-observation", 0)
+		logger := telemetry.NewTelemetryLogger(log.New(&logBuf, "ocr3-test-observation", 0), io.Discard)
 
 		metadataStore := &mockMetadataStore{
 			GetBlockHistoryFn: func() ocr2keepers.BlockHistory {
@@ -787,7 +788,7 @@ func TestOcr3Plugin_Observation(t *testing.T) {
 
 	t.Run("subsequent round processing, previous outcome will be non nil, when AddConditionalProposalsHook errors, an error is returned", func(t *testing.T) {
 		var logBuf bytes.Buffer
-		logger := log.New(&logBuf, "ocr3-test-observation", 0)
+		logger := telemetry.NewTelemetryLogger(log.New(&logBuf, "ocr3-test-observation", 0), io.Discard)
 
 		metadataStore := &mockMetadataStore{
 			GetBlockHistoryFn: func() ocr2keepers.BlockHistory {
@@ -916,7 +917,7 @@ func TestOcr3Plugin_Observation(t *testing.T) {
 
 	t.Run("subsequent round processing, decoding an invalid previous outcome returns an error", func(t *testing.T) {
 		plugin := &ocr3Plugin{
-			Logger: log.New(io.Discard, "", 1),
+			Logger: telemetry.NewTelemetryLogger(log.New(io.Discard, "", 1), io.Discard),
 		}
 
 		outcomeCtx := ocr3types.OutcomeContext{
@@ -985,7 +986,7 @@ func TestOcr3Plugin_ValidateObservation(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			plugin := &ocr3Plugin{
-				Logger:           log.New(io.Discard, "ocr3-validate-observation-test", log.Ldate),
+				Logger:           telemetry.NewTelemetryLogger(log.New(io.Discard, "ocr3-validate-observation-test", log.Ldate), io.Discard),
 				UpkeepTypeGetter: mockUpkeepTypeGetter,
 				WorkIDGenerator:  tc.wg,
 			}
@@ -1085,7 +1086,7 @@ func TestOcr3Plugin_Outcome(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			var logBuf bytes.Buffer
-			logger := log.New(&logBuf, "ocr3-test-outcome", 0)
+			logger := telemetry.NewTelemetryLogger(log.New(&logBuf, "ocr3-test-observation", 0), io.Discard)
 
 			plugin := &ocr3Plugin{
 				UpkeepTypeGetter: mockUpkeepTypeGetter,
@@ -1265,7 +1266,7 @@ func TestOcr3Plugin_Reports(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			var logBuf bytes.Buffer
-			logger := log.New(&logBuf, "ocr3-test-reports", 0)
+			logger := telemetry.NewTelemetryLogger(log.New(&logBuf, "ocr3-test-observation", 0), io.Discard)
 
 			plugin := &ocr3Plugin{
 				Logger:           logger,
@@ -1367,7 +1368,7 @@ func TestOcr3Plugin_ShouldAcceptAttestedReport(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			var logBuf bytes.Buffer
-			logger := log.New(&logBuf, "ocr3-test-shouldAcceptAttestedReport", 0)
+			logger := telemetry.NewTelemetryLogger(log.New(&logBuf, "ocr3-test-shouldAcceptAttestedReport", 0), io.Discard)
 
 			plugin := &ocr3Plugin{
 				Logger:        logger,
@@ -1462,7 +1463,7 @@ func TestOcr3Plugin_ShouldTransmitAcceptedReport(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			var logBuf bytes.Buffer
-			logger := log.New(&logBuf, "ocr3-test-shouldAcceptAttestedReport", 0)
+			logger := telemetry.NewTelemetryLogger(log.New(&logBuf, "ocr3-test-shouldAcceptAttestedReport", 0), io.Discard)
 
 			plugin := &ocr3Plugin{
 				Logger:        logger,
@@ -1483,7 +1484,7 @@ func TestOcr3Plugin_ShouldTransmitAcceptedReport(t *testing.T) {
 
 func TestOcr3Plugin_startServices(t *testing.T) {
 	var logBuf bytes.Buffer
-	logger := log.New(&logBuf, "ocr3-test-shouldAcceptAttestedReport", 0)
+	logger := telemetry.NewTelemetryLogger(log.New(&logBuf, "ocr3-test-shouldAcceptAttestedReport", 0), io.Discard)
 
 	startedCh := make(chan struct{}, 1)
 	plugin := &ocr3Plugin{

--- a/pkg/v3/plugin/performable_test.go
+++ b/pkg/v3/plugin/performable_test.go
@@ -2,6 +2,7 @@ package plugin
 
 import (
 	"bytes"
+	"io"
 	"log"
 	"math/big"
 	"testing"
@@ -9,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	ocr2keepers "github.com/smartcontractkit/chainlink-automation/pkg/v3"
+	"github.com/smartcontractkit/chainlink-automation/pkg/v3/telemetry"
 	"github.com/smartcontractkit/chainlink-automation/pkg/v3/types"
 )
 
@@ -370,7 +372,7 @@ func TestPerformables(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// Prepare logger
 			var logBuf bytes.Buffer
-			logger := log.New(&logBuf, "", 0)
+			logger := telemetry.NewTelemetryLogger(log.New(&logBuf, "", 0), io.Discard)
 			performables := newPerformables(tt.threshold, tt.limit, [16]byte{}, logger)
 			for _, observation := range tt.observations {
 				performables.add(observation)

--- a/pkg/v3/postprocessors/eligible_test.go
+++ b/pkg/v3/postprocessors/eligible_test.go
@@ -10,12 +10,14 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/smartcontractkit/chainlink-automation/pkg/v3/stores"
+	"github.com/smartcontractkit/chainlink-automation/pkg/v3/telemetry"
 	ocr2keepers "github.com/smartcontractkit/chainlink-automation/pkg/v3/types"
 )
 
 func TestNewEligiblePostProcessor(t *testing.T) {
 	resultsStore := stores.New(log.New(io.Discard, "", 0))
-	processor := NewEligiblePostProcessor(resultsStore, log.New(io.Discard, "", 0))
+	lggr := telemetry.NewTelemetryLogger(log.New(io.Discard, "", 0), io.Discard)
+	processor := NewEligiblePostProcessor(resultsStore, lggr)
 
 	t.Run("process eligible results", func(t *testing.T) {
 		result1 := ocr2keepers.CheckResult{Eligible: false}

--- a/pkg/v3/postprocessors/ineligible_test.go
+++ b/pkg/v3/postprocessors/ineligible_test.go
@@ -4,12 +4,14 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"io"
 	"log"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/smartcontractkit/chainlink-automation/pkg/v3/telemetry"
 	"github.com/smartcontractkit/chainlink-automation/pkg/v3/types"
 )
 
@@ -90,7 +92,10 @@ upkeep state boom`),
 			var buf bytes.Buffer
 			l := log.Default()
 			l.SetOutput(&buf)
-			processor := NewIneligiblePostProcessor(tc.stateUpdater, l)
+
+			lggr := telemetry.NewTelemetryLogger(l, io.Discard)
+
+			processor := NewIneligiblePostProcessor(tc.stateUpdater, lggr)
 
 			err := processor.PostProcess(context.Background(), tc.results, nil)
 			if tc.expectsErr {

--- a/pkg/v3/postprocessors/retry.go
+++ b/pkg/v3/postprocessors/retry.go
@@ -10,7 +10,7 @@ import (
 	ocr2keepers "github.com/smartcontractkit/chainlink-automation/pkg/v3/types"
 )
 
-func NewRetryablePostProcessor(q ocr2keepers.RetryQueue, logger *log.Logger) *retryablePostProcessor {
+func NewRetryablePostProcessor(q ocr2keepers.RetryQueue, logger *telemetry.Logger) *retryablePostProcessor {
 	return &retryablePostProcessor{
 		logger: log.New(logger.Writer(), fmt.Sprintf("[%s | retryable-post-processor]", telemetry.ServiceName), telemetry.LogPkgStdFlags),
 		q:      q,

--- a/pkg/v3/postprocessors/retry_test.go
+++ b/pkg/v3/postprocessors/retry_test.go
@@ -2,6 +2,7 @@ package postprocessors
 
 import (
 	"context"
+	"io"
 	"log"
 	"testing"
 	"time"
@@ -9,11 +10,13 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/smartcontractkit/chainlink-automation/pkg/v3/stores"
+	"github.com/smartcontractkit/chainlink-automation/pkg/v3/telemetry"
 	ocr2keepers "github.com/smartcontractkit/chainlink-automation/pkg/v3/types"
 )
 
 func TestRetryPostProcessor_PostProcess(t *testing.T) {
-	lggr := log.Default()
+	lggr := telemetry.NewTelemetryLogger(log.Default(), io.Discard)
+
 	q := stores.NewRetryQueue(lggr)
 	processor := NewRetryablePostProcessor(q, lggr)
 

--- a/pkg/v3/postprocessors/telemetry_status.go
+++ b/pkg/v3/postprocessors/telemetry_status.go
@@ -1,0 +1,30 @@
+package postprocessors
+
+import (
+	"context"
+
+	"github.com/smartcontractkit/chainlink-automation/pkg/v3/telemetry"
+	ocr2keepers "github.com/smartcontractkit/chainlink-automation/pkg/v3/types"
+)
+
+func NewTelemetryStatus(status telemetry.Status, logger *telemetry.Logger) *TelemetryStatus {
+	return &TelemetryStatus{
+		status: status,
+		logger: logger,
+	}
+}
+
+type TelemetryStatus struct {
+	status telemetry.Status
+	logger *telemetry.Logger
+}
+
+func (p *TelemetryStatus) PostProcess(_ context.Context, results []ocr2keepers.CheckResult, _ []ocr2keepers.UpkeepPayload) error {
+	for _, payload := range results {
+		if err := p.logger.Collect(payload.WorkID, uint64(payload.Trigger.BlockNumber), p.status); err != nil {
+			p.logger.Println(err)
+		}
+	}
+
+	return nil
+}

--- a/pkg/v3/preprocessors/telemetry_status.go
+++ b/pkg/v3/preprocessors/telemetry_status.go
@@ -1,0 +1,33 @@
+package preprocessors
+
+import (
+	"context"
+
+	"github.com/smartcontractkit/chainlink-automation/pkg/v3/telemetry"
+	ocr2keepers "github.com/smartcontractkit/chainlink-automation/pkg/v3/types"
+)
+
+func NewTelemetryStatus(status telemetry.Status, logger *telemetry.Logger) *TelemetryStatus {
+	return &TelemetryStatus{
+		status: status,
+		logger: logger,
+	}
+}
+
+type TelemetryStatus struct {
+	status telemetry.Status
+	logger *telemetry.Logger
+}
+
+func (p *TelemetryStatus) PreProcess(
+	ctx context.Context,
+	payloads []ocr2keepers.UpkeepPayload,
+) ([]ocr2keepers.UpkeepPayload, error) {
+	for _, payload := range payloads {
+		if err := p.logger.Collect(payload.WorkID, uint64(payload.Trigger.BlockNumber), p.status); err != nil {
+			p.logger.Println(err)
+		}
+	}
+
+	return payloads, nil
+}

--- a/pkg/v3/stores/retry_queue.go
+++ b/pkg/v3/stores/retry_queue.go
@@ -49,7 +49,7 @@ type retryQueue struct {
 
 var _ types.RetryQueue = (*retryQueue)(nil)
 
-func NewRetryQueue(lggr *log.Logger) *retryQueue {
+func NewRetryQueue(lggr *telemetry.Logger) *retryQueue {
 	return &retryQueue{
 		lggr:       log.New(lggr.Writer(), fmt.Sprintf("[%s | retry-queue]", telemetry.ServiceName), telemetry.LogPkgStdFlags),
 		records:    map[string]retryQueueRecord{},

--- a/pkg/v3/stores/retry_queue_test.go
+++ b/pkg/v3/stores/retry_queue_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/smartcontractkit/chainlink-automation/pkg/v3/telemetry"
 	ocr2keepers "github.com/smartcontractkit/chainlink-automation/pkg/v3/types"
 )
 
@@ -32,7 +33,7 @@ func TestRetryQueue_Sanity(t *testing.T) {
 	revert := overrideDefaults(defaultExpiration, retryInterval)
 	defer revert()
 
-	q := NewRetryQueue(log.New(io.Discard, "", 0))
+	q := NewRetryQueue(telemetry.NewTelemetryLogger(log.New(io.Discard, "", 0), io.Discard))
 
 	err := q.Enqueue(
 		newRetryRecord(ocr2keepers.UpkeepPayload{WorkID: "1"}, 0),
@@ -81,7 +82,7 @@ func TestRetryQueue_Expiration(t *testing.T) {
 	revert := overrideDefaults(defaultExpiration, retryInterval)
 	defer revert()
 
-	q := NewRetryQueue(log.New(io.Discard, "", 0))
+	q := NewRetryQueue(telemetry.NewTelemetryLogger(log.New(io.Discard, "", 0), io.Discard))
 
 	t.Run("dequeue before expiration", func(t *testing.T) {
 		err := q.Enqueue(

--- a/pkg/v3/telemetry/log.go
+++ b/pkg/v3/telemetry/log.go
@@ -2,7 +2,23 @@ package telemetry
 
 import (
 	"fmt"
+	"io"
 	"log"
+	"time"
+)
+
+type Status int
+
+const (
+	Surfaced Status = iota
+	CheckPipelineRun
+	Queued
+	Proposed
+	AgreedInQuorum
+	ResultProposed
+	ResultAgreedInQuorum
+	Reported
+	Completed
 )
 
 const (
@@ -12,4 +28,35 @@ const (
 
 func WrapLogger(logger *log.Logger, ns string) *log.Logger {
 	return log.New(logger.Writer(), fmt.Sprintf("[%s | %s]", ServiceName, ns), LogPkgStdFlags)
+}
+
+func WrapTelemetryLogger(logger *Logger, ns string) *Logger {
+	baseLogger := log.New(logger.Writer(), fmt.Sprintf("[%s | %s]", ServiceName, ns), LogPkgStdFlags)
+
+	return &Logger{
+		Logger:    baseLogger,
+		collector: logger.collector,
+	}
+}
+
+type Logger struct {
+	*log.Logger
+	collector io.Writer
+}
+
+func NewTelemetryLogger(logger *log.Logger, collector io.Writer) *Logger {
+	return &Logger{
+		Logger:    logger,
+		collector: collector,
+	}
+}
+
+func (l *Logger) Collect(key string, block uint64, status Status) error {
+	_, err := l.collector.Write([]byte(fmt.Sprintf(`{"key":"%s","block":%d,"status":%d,"time":"%s"}`, key, block, status, time.Now().Format(time.RFC3339Nano))))
+
+	return err
+}
+
+func (l *Logger) GetLogger() *log.Logger {
+	return l.Logger
 }

--- a/tools/simulator/node/add.go
+++ b/tools/simulator/node/add.go
@@ -27,6 +27,7 @@ func (g *Group) Add(conf config.Node) {
 	var rpcTel *telemetry.RPCCollector
 	var logTel *telemetry.NodeLogCollector
 	var ctrTel *telemetry.ContractEventCollector
+	var stsTel *telemetry.UpkeepStatusCollector
 
 	for _, col := range g.collectors {
 		switch cT := col.(type) {
@@ -36,6 +37,8 @@ func (g *Group) Add(conf config.Node) {
 			logTel = cT
 		case *telemetry.ContractEventCollector:
 			ctrTel = cT
+		case *telemetry.UpkeepStatusCollector:
+			stsTel = cT
 		}
 	}
 
@@ -52,6 +55,7 @@ func (g *Group) Add(conf config.Node) {
 	_ = logTel.AddNode(simNet.PeerID())
 	_ = rpcTel.AddNode(simNet.PeerID())
 	_ = ctrTel.AddNode(simNet.PeerID())
+	_ = stsTel.AddNode(simNet.PeerID())
 
 	// general logger
 	var slogger *simio.SimpleLogger
@@ -87,6 +91,7 @@ func (g *Group) Add(conf config.Node) {
 		OnchainKeyring:         onchainRing,
 		MaxServiceWorkers:      conf.MaxServiceWorkers,
 		ServiceQueueLength:     conf.MaxQueueSize,
+		TelemetryWriter:        stsTel.Writer(simNet.PeerID()),
 	}
 
 	_ = simulate.HydrateConfig(

--- a/tools/simulator/node/report.go
+++ b/tools/simulator/node/report.go
@@ -38,6 +38,18 @@ func (g *Group) WriteTransmitChart() {
 	fmt.Fprint(g.logger.Writer(), tw.Render())
 	// the render function does not put a newline after the chart
 	fmt.Fprint(g.logger.Writer(), "\n\n")
+
+	var stsTel *telemetry.UpkeepStatusCollector
+
+	for _, col := range g.collectors {
+		switch cT := col.(type) {
+		case *telemetry.UpkeepStatusCollector:
+			stsTel = cT
+		}
+	}
+
+	fmt.Fprint(g.logger.Writer(), stsTel.PrintTabularResults())
+	fmt.Fprint(g.logger.Writer(), "\n\n")
 }
 
 func (g *Group) ReportResults() {

--- a/tools/simulator/run/output.go
+++ b/tools/simulator/run/output.go
@@ -17,6 +17,7 @@ type Outputs struct {
 	RPCCollector            *telemetry.RPCCollector
 	LogCollector            *telemetry.NodeLogCollector
 	EventCollector          *telemetry.ContractEventCollector
+	StatusCollector         *telemetry.UpkeepStatusCollector
 	simulationLogFileHandle *os.File
 }
 
@@ -35,10 +36,11 @@ func SetupOutput(path string, simulate, verbose bool, plan config.SimulationPlan
 		logger := log.New(io.Discard, "", 0)
 
 		return &Outputs{
-			SimulationLog:  logger,
-			RPCCollector:   telemetry.NewNodeRPCCollector("", false),
-			LogCollector:   telemetry.NewNodeLogCollector("", false),
-			EventCollector: telemetry.NewContractEventCollector(logger),
+			SimulationLog:   logger,
+			RPCCollector:    telemetry.NewNodeRPCCollector("", false),
+			LogCollector:    telemetry.NewNodeLogCollector("", false),
+			EventCollector:  telemetry.NewContractEventCollector(logger),
+			StatusCollector: telemetry.NewUpkeepStatusCollector(path, false),
 		}, nil
 	}
 
@@ -74,6 +76,7 @@ func SetupOutput(path string, simulate, verbose bool, plan config.SimulationPlan
 		RPCCollector:            telemetry.NewNodeRPCCollector(path, true),
 		LogCollector:            telemetry.NewNodeLogCollector(path, true),
 		EventCollector:          telemetry.NewContractEventCollector(logger),
+		StatusCollector:         telemetry.NewUpkeepStatusCollector(path, true),
 		simulationLogFileHandle: lggF,
 	}, nil
 }

--- a/tools/simulator/telemetry/base.go
+++ b/tools/simulator/telemetry/base.go
@@ -14,6 +14,7 @@ type CollectorType int
 const (
 	RPCType CollectorType = iota
 	NodeLogType
+	UpkeepStatusType
 )
 
 type baseCollector struct {

--- a/tools/simulator/telemetry/status.go
+++ b/tools/simulator/telemetry/status.go
@@ -1,0 +1,318 @@
+package telemetry
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"sort"
+	"time"
+	"unicode/utf8"
+
+	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/smartcontractkit/chainlink-automation/pkg/v3/telemetry"
+)
+
+func NewUpkeepStatusCollector(path string, verbose bool) *UpkeepStatusCollector {
+	err := os.MkdirAll(path, 0750)
+	if err != nil && !os.IsExist(err) {
+		panic(err)
+	}
+
+	return &UpkeepStatusCollector{
+		baseCollector: baseCollector{
+			t:        UpkeepStatusType,
+			io:       []io.WriteCloser{},
+			ioLookup: make(map[string]int),
+		},
+		filePath: path,
+		nodes:    make(map[string]*WrappedUpkeepStatusCollector),
+		verbose:  verbose,
+	}
+}
+
+type UpkeepStatusCollector struct {
+	baseCollector
+	filePath string
+	nodes    map[string]*WrappedUpkeepStatusCollector
+	verbose  bool
+}
+
+func (c *UpkeepStatusCollector) AddNode(node string) error {
+	var path string
+
+	if c.verbose {
+		path = fmt.Sprintf("%s/%s", c.filePath, node)
+
+		if err := os.MkdirAll(path, 0750); err != nil && !os.IsExist(err) {
+			panic(err)
+		}
+	}
+
+	var file io.WriteCloser
+
+	if !c.verbose {
+		file = writeCloseDiscard{}
+	} else {
+		var perms fs.FileMode = 0666
+
+		flag := os.O_RDWR | os.O_CREATE | os.O_TRUNC
+
+		var err error
+
+		file, err = os.OpenFile(fmt.Sprintf("%s/upkeep_telemetry.log", path), flag, perms)
+		if err != nil {
+			file.Close()
+
+			return err
+		}
+	}
+
+	c.ioLookup[node] = len(c.io)
+	c.io = append(c.io, file)
+
+	c.nodes[node] = &WrappedUpkeepStatusCollector{
+		writer: file,
+		data:   make([][]byte, 0, 1000),
+	}
+
+	return nil
+}
+
+func (c *UpkeepStatusCollector) addWriterForKey(path, key string) error {
+	if !c.verbose {
+		c.ioLookup[key] = len(c.io)
+		c.io = append(c.io, writeCloseDiscard{})
+
+		return nil
+	}
+
+	var perms fs.FileMode = 0666
+
+	flag := os.O_RDWR | os.O_CREATE | os.O_TRUNC
+
+	file, err := os.OpenFile(path, flag, perms)
+	if err != nil {
+		file.Close()
+
+		return err
+	}
+
+	c.ioLookup[key] = len(c.io)
+	c.io = append(c.io, file)
+
+	return nil
+}
+func (c *UpkeepStatusCollector) Writer(node string) *WrappedUpkeepStatusCollector {
+	collector, exists := c.nodes[node]
+	if !exists {
+		panic("node does not exist")
+	}
+
+	return collector
+}
+
+func (c *UpkeepStatusCollector) PrintTabularResults() string {
+	tw := table.NewWriter()
+	tw.SetTitle("Status Delays per Work ID")
+	tw.AppendHeader(table.Row{
+		"ID",
+		"Surfaced",
+		"Proposed",
+		"Proposal Quorum",
+		"Result Proposed",
+		"Result Quorum",
+		"Reported",
+		"Completed",
+	})
+
+	points, err := c.parseData()
+	if err != nil {
+		panic(err)
+	}
+	data := c.collapseData(points)
+
+	for _, upkeep := range data {
+		tw.AppendRow(
+			table.Row{
+				shorten(upkeep.ID, 8),
+				upkeep.Count(telemetry.Surfaced),
+				formatPoint(upkeep, telemetry.Proposed),
+				formatPoint(upkeep, telemetry.AgreedInQuorum),
+				formatPoint(upkeep, telemetry.ResultProposed),
+				formatPoint(upkeep, telemetry.ResultAgreedInQuorum),
+				formatPoint(upkeep, telemetry.Reported),
+				formatPoint(upkeep, telemetry.Completed),
+			})
+	}
+
+	return tw.Render()
+}
+
+func (c *UpkeepStatusCollector) collapseData(points [][]statusPoint) map[string]*upkeepCompletion {
+	mapper := make(map[string]*upkeepCompletion)
+
+	for _, nodePoints := range points {
+		for _, point := range nodePoints {
+			com, exists := mapper[point.ID]
+			if !exists {
+				com = newUpkeepCompletion(point.ID)
+
+				com.Add(point)
+
+				mapper[point.ID] = com
+			}
+
+			com.Add(point)
+		}
+	}
+
+	return mapper
+}
+
+func (c *UpkeepStatusCollector) parseData() ([][]statusPoint, error) {
+	points := [][]statusPoint{}
+
+	for _, node := range c.nodes {
+		nodePoints := []statusPoint{}
+
+		for _, data := range node.data {
+			var point statusPoint
+
+			if err := json.Unmarshal(data, &point); err != nil {
+				return nil, err
+			}
+
+			nodePoints = append(nodePoints, point)
+		}
+
+		points = append(points, nodePoints)
+
+		// break
+	}
+
+	return points, nil
+}
+
+func formatPoint(upkeep *upkeepCompletion, status telemetry.Status) string {
+	return fmt.Sprintf("%d:%s", upkeep.Count(status), upkeep.Between(telemetry.Surfaced, status))
+}
+
+type WrappedUpkeepStatusCollector struct {
+	writer io.Writer
+	data   [][]byte
+}
+
+func (c *WrappedUpkeepStatusCollector) Write(data []byte) (int, error) {
+	c.data = append(c.data, data)
+
+	return c.writer.Write(data)
+}
+
+type statusPoint struct {
+	ID     string   `json:"key"`
+	Block  uint64   `json:"block"`
+	Status int      `json:"status"`
+	Time   NanoTime `json:"time"`
+}
+
+type NanoTime time.Time
+
+func (t *NanoTime) UnmarshalJSON(data []byte) error {
+
+	var raw string
+
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	tm, err := time.Parse(time.RFC3339Nano, raw)
+	if err != nil {
+		return err
+	}
+
+	*t = NanoTime(tm)
+
+	return nil
+}
+
+func newUpkeepCompletion(id string) *upkeepCompletion {
+	return &upkeepCompletion{
+		ID:        id,
+		statusMap: make(map[int][]time.Time),
+	}
+}
+
+type upkeepCompletion struct {
+	ID        string
+	statusMap map[int][]time.Time
+}
+
+func (c *upkeepCompletion) Add(point statusPoint) {
+	times, exist := c.statusMap[point.Status]
+	if !exist {
+		times = []time.Time{}
+	}
+
+	times = append(times, time.Time(point.Time))
+
+	c.statusMap[point.Status] = times
+}
+
+func (c *upkeepCompletion) Count(status telemetry.Status) int {
+	times, exist := c.statusMap[int(status)]
+	if !exist {
+		return 0
+	}
+
+	return len(times)
+}
+
+func (c *upkeepCompletion) Earliest(status telemetry.Status) (time.Time, error) {
+	times, exist := c.statusMap[int(status)]
+	if !exist || len(times) == 0 {
+		return time.Now(), fmt.Errorf("status does not exist")
+	}
+
+	sort.Slice(times, func(i, j int) bool {
+		return times[i].Compare(times[j]) < 0
+	})
+
+	return times[0], nil
+}
+
+func (c *upkeepCompletion) Latest(status telemetry.Status) (time.Time, error) {
+	times, exist := c.statusMap[int(status)]
+	if !exist || len(times) == 0 {
+		return time.Now(), fmt.Errorf("status does not exist")
+	}
+
+	sort.Slice(times, func(i, j int) bool {
+		return times[i].Compare(times[j]) > 0
+	})
+
+	return times[0], nil
+}
+
+func (c *upkeepCompletion) Between(start, end telemetry.Status) time.Duration {
+	startTime, err := c.Earliest(start)
+	if err != nil {
+		return 0
+	}
+
+	endTime, err := c.Latest(end)
+	if err != nil {
+		return 0
+	}
+
+	return endTime.Sub(startTime)
+}
+
+func shorten(full string, outLen int) string {
+	if utf8.RuneCountInString(full) < outLen {
+		return full
+	}
+
+	return string([]byte(full)[:outLen])
+}


### PR DESCRIPTION
Relying on log output for debugging has been challenging at best and error prone at worst. This is frequently due to the fluctuating nature of full text log output as changes occur in the code base. On top of that, log collection at a full debug level for simple state telemetry is highly wasteful as most of the log output doesn't directly relate to state changes.

This proposal introduces distinct states of a specific upkeep that are indicated as being altered at specific points in the program. The approach replaces the default logger with a special telemetry logger that adds telemetry logging functions.

To view potential output of the telemetry logging, run the following in a local terminal:

```
$ make simulator && ./bin/simulator --simulate --verbose -f ./tools/simulator/plans/only_log_trigger.json
```

Then view `./simulation_plan_logs/simulation.log` for "Status Delays per Work ID". The output attempts to indicated the time taken for an upkeep to reach specific states. This allows for evaluation of the time spent at each point in the process.