### PR TITLE
[DO NOT MERGE] Simulate failed pipeline state

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -79,7 +79,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        plan: ["simplan_fast_check", "only_log_trigger"]
+        plan: ["simplan_fast_check", "only_log_trigger", "pipeline_failure_recovery"]
 
     name: Upkeep Simulation ${{ matrix.plan }}
 

--- a/tools/simulator/config/event.go
+++ b/tools/simulator/config/event.go
@@ -92,6 +92,27 @@ type GenerateUpkeepEvent struct {
 	// not perform due to some other network concerns such as too high network
 	// delay or something that might disable the OCR3 protocol.
 	Expected string `json:"expected,omitempty"`
+	// Overrides provides customizations on upkeeps including check pipeline behavior.
+	// Only one configuration per upkeep is supported.
+	Overrides []UpkeepOverrides `json:"overrides,omitempty"`
+}
+
+type UpkeepOverrides struct {
+	// UpkeepID references the upkeep id generated from StartID + Count. This
+	// value is NOT the final upkeep id referenced by the plugin.
+	UpkeepID *big.Int `json:"id"`
+	// Pattern defines the pipeline return behavior. A '1' indicates a failure
+	// and a '0' indicates a non-failure. The pattern is structured like a count
+	// where each pipeline run on the defined upkeep increments the position in
+	// the pattern. At the end of the pattern, it repeats from the beginning.
+	FailurePattern string `json:"pipelineFailurePattern,omitempty"`
+	// Retryable indicates whether or not the retryable flag should be set on the
+	// pipeline result. Setting this will always set the retryable flag for the
+	// provided upkeep.
+	RetryableOnFailure bool `json:"retryableOnFailure"`
+	// Expected overrides the container expectation configuration in the case that
+	// specific upkeep configurations make the upkeep fail.
+	Expected bool `json:"expected"`
 }
 
 // LogTriggerEvent is a configuration for simulating logs emitted from a chain

--- a/tools/simulator/plans/pipeline_failure_recovery.json
+++ b/tools/simulator/plans/pipeline_failure_recovery.json
@@ -1,0 +1,111 @@
+{
+    "node": {
+        "totalNodeCount": 4,
+        "maxNodeServiceWorkers": 100,
+        "maxNodeServiceQueueSize": 1000
+    },
+    "p2pNetwork": {
+        "maxLatency": "100ms"
+    },
+    "rpc": {
+        "maxBlockDelay": 600,
+        "averageLatency": 300,
+        "errorRate": 0.02,
+        "rateLimitThreshold": 1000
+    },
+    "blocks": {
+        "genesisBlock": 128943862,
+        "blockCadence": "1s",
+        "durationInBlocks": 60,
+        "endPadding": 20
+    },
+    "events": [
+        {
+            "type": "ocr3config",
+            "eventBlockNumber": 128943863,
+            "comment": "initial ocr config (valid)",
+            "maxFaultyNodes": 1,
+            "encodedOffchainConfig": "{\"version\":\"v3\",\"performLockoutWindow\":100000,\"targetProbability\":\"0.999\",\"targetInRounds\":4,\"minConfirmations\":1,\"gasLimitPerReport\":1000000,\"gasOverheadPerUpkeep\":300000,\"maxUpkeepBatchSize\":10}",
+            "maxRoundsPerEpoch": 7,
+            "deltaProgress": "10s",
+            "deltaResend": "10s",
+            "deltaInitial": "300ms",
+            "deltaRound": "1100ms",
+            "deltaGrace": "300ms",
+            "deltaCertifiedCommitRequest": "200ms",
+            "deltaStage": "20s",
+            "maxQueryTime": "50ms",
+            "maxObservationTime": "100ms",
+            "maxShouldAcceptTime": "50ms",
+            "maxShouldTransmitTime": "50ms"
+        },
+        {
+            "type": "generateUpkeeps",
+            "eventBlockNumber": 128943862,
+            "comment": "single log triggered upkeep",
+            "count": 1,
+            "startID": 300,
+            "eligibilityFunc": "always",
+            "upkeepType": "logTrigger",
+            "logTriggeredBy": "test_trigger_event"
+        },
+        {
+            "type": "generateUpkeeps",
+            "eventBlockNumber": 128943864,
+            "comment": "5 log triggered upkeeps",
+            "count": 5,
+            "startID": 400,
+            "eligibilityFunc": "always",
+            "upkeepType": "logTrigger",
+            "logTriggeredBy": "test_trigger_event",
+            "overrides": [
+                {
+                    "id": 401,
+                    "pipelineFailurePattern": "111000000",
+                    "retryableOnFailure": true,
+                    "expected": true
+                },
+                {
+                    "id": 402,
+                    "pipelineFailurePattern": "1",
+                    "retryableOnFailure": true,
+                    "expected": false
+                },
+                {
+                    "id": 403,
+                    "pipelineFailurePattern": "1000100",
+                    "retryableOnFailure": true,
+                    "expected": true
+                }
+            ]
+        },
+        {
+            "type": "logTrigger",
+            "eventBlockNumber": 128943872,
+            "comment": "trigger 10 blocks after trigger upkeep created",
+            "triggerValue": "test_trigger_event"
+        },
+        {
+            "type": "generateUpkeeps",
+            "eventBlockNumber": 128943878,
+            "comment": "7 log triggered upkeeps",
+            "count": 7,
+            "startID": 500,
+            "eligibilityFunc": "always",
+            "upkeepType": "logTrigger",
+            "logTriggeredBy": "test_trigger_event"
+        },
+        {
+            "type": "logTrigger",
+            "eventBlockNumber": 128943882,
+            "comment": "trigger 10 blocks after trigger upkeep created",
+            "triggerValue": "test_trigger_event"
+        },
+        {
+            "type": "logTrigger",
+            "eventBlockNumber": 128943892,
+            "comment": "trigger 10 blocks after trigger upkeep created",
+            "triggerValue": "test_trigger_event"
+        }
+    ]
+}

--- a/tools/simulator/simulate/chain/block_test.go
+++ b/tools/simulator/simulate/chain/block_test.go
@@ -1,0 +1,32 @@
+package chain_test
+
+import (
+	"testing"
+
+	"github.com/smartcontractkit/chainlink-automation/tools/simulator/simulate/chain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetNextState(t *testing.T) {
+	tests := []struct {
+		pattern string
+		err     error
+		states  []int
+	}{
+		{"0", nil, []int{0, 0, 0}},
+		{"1", nil, []int{1, 1, 1}},
+		{"", nil, []int{0, 0, 0}},
+		{"0001000101", nil, []int{0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0, 0, 0, 1}},
+	}
+
+	for _, test := range tests {
+		manager, err := chain.NewCheckPipelineStateManager(test.pattern)
+
+		require.ErrorIs(t, err, test.err)
+
+		for idx, expected := range test.states {
+			assert.Equal(t, expected, manager.GetNextState(), "state should match for %d", idx)
+		}
+	}
+}

--- a/tools/simulator/simulate/upkeep/pipeline.go
+++ b/tools/simulator/simulate/upkeep/pipeline.go
@@ -50,48 +50,7 @@ func NewCheckPipeline(
 	}
 }
 
-// TODO: finish retry/error conditions in check pipeline
-// CheckUpkeeps simulates a check pipeline run and may return whether a result
-// is eligible or retryable based on pipeline return cases. Multiple assumptions
-// are made within this simulation and any changes to the production pipeline
-// should be reflected here.
-/*
-func (cp *CheckPipeline) CheckUpkeeps(ctx context.Context, payloads ...ocr2keepers.UpkeepPayload) ([]ocr2keepers.CheckResult, error) {
-	results := make([]ocr2keepers.CheckResult, len(payloads))
-
-	for i, payload := range payloads {
-
-		// 1. verify check block and hash are valid
-		// 1a. check block too old: no failure reason, not retryable, not eligible,
-
-		// 1. upkeep active status
-		// _, ok := cp.active.GetByID(payload.UpkeepID.BigInt())
-		//if !ok {
-		results[i] = ocr2keepers.CheckResult{
-			PipelineExecutionState: 0,
-			Retryable:              false,
-			Eligible:               true,
-			IneligibilityReason:    0,
-			UpkeepID:               payload.UpkeepID,
-			Trigger:                payload.Trigger,
-			WorkID:                 payload.WorkID,
-			GasAllocated:           5_000_000, // TODO: update from config
-			PerformData:            []byte{},  // TODO: update from config
-			FastGasWei:             big.NewInt(1_000_000),
-			LinkNative:             big.NewInt(1_000_000),
-		}
-		//}
-
-		// 2. log triggered status; was the payload triggered by a log (if log trigger type)
-		// 3. eligibility status
-		// 4. performed status
-	}
-
-	return results, nil
-}
-*/
-
-func (cp *CheckPipeline) CheckUpkeeps(ctx context.Context, payloads ...ocr2keepers.UpkeepPayload) ([]ocr2keepers.CheckResult, error) {
+func (p *CheckPipeline) CheckUpkeeps(ctx context.Context, payloads ...ocr2keepers.UpkeepPayload) ([]ocr2keepers.CheckResult, error) {
 	var (
 		mErr    error
 		wg      sync.WaitGroup
@@ -103,36 +62,9 @@ func (cp *CheckPipeline) CheckUpkeeps(ctx context.Context, payloads ...ocr2keepe
 		go func(resultIdx int, key ocr2keepers.UpkeepPayload) {
 			defer wg.Done()
 
-			block := new(big.Int).SetInt64(int64(key.Trigger.BlockNumber))
-			performs := cp.performs.PerformsForUpkeepID(key.UpkeepID.String())
+			p.checkTelemetry.CheckID(key.UpkeepID.String(), uint64(key.Trigger.BlockNumber), key.Trigger.BlockHash)
 
-			cp.checkTelemetry.CheckID(key.UpkeepID.String(), uint64(key.Trigger.BlockNumber), key.Trigger.BlockHash)
-
-			results[resultIdx] = ocr2keepers.CheckResult{
-				PipelineExecutionState: 0,
-				Retryable:              false,
-				Eligible:               false,
-				IneligibilityReason:    0,
-				UpkeepID:               key.UpkeepID,
-				Trigger:                key.Trigger,
-				WorkID:                 key.WorkID,
-				GasAllocated:           5_000_000, // TODO: make this configurable
-				PerformData:            []byte{},  // TODO: add perform data from configuration
-				FastGasWei:             big.NewInt(1_000_000),
-				LinkNative:             big.NewInt(1_000_000),
-			}
-
-			if simulated, ok := cp.active.GetByUpkeepID(key.UpkeepID); ok {
-				if simulated.AlwaysEligible {
-					results[resultIdx].Eligible = true
-				} else {
-					results[resultIdx].Eligible = isEligible(simulated.EligibleAt, performs, block)
-				}
-
-				cp.logger.Printf("%s eligibility %t at block %d", key.UpkeepID, results[resultIdx].Eligible, block)
-			} else {
-				cp.logger.Printf("%s is not active", key.UpkeepID)
-			}
+			results[resultIdx] = p.makeResult(key)
 		}(idx, payload)
 	}
 
@@ -143,13 +75,13 @@ func (cp *CheckPipeline) CheckUpkeeps(ctx context.Context, payloads ...ocr2keepe
 	}
 
 	// call to CheckUpkeep
-	err := <-cp.rpc.Call(ctx, "checkUpkeep")
+	err := <-p.rpc.Call(ctx, "checkUpkeep")
 	if err != nil {
 		return nil, err
 	}
 
 	// call to SimulatePerform
-	err = <-cp.rpc.Call(ctx, "simulatePerform")
+	err = <-p.rpc.Call(ctx, "simulatePerform")
 	if err != nil {
 		return nil, err
 	}
@@ -158,6 +90,45 @@ func (cp *CheckPipeline) CheckUpkeeps(ctx context.Context, payloads ...ocr2keepe
 	copy(output, results)
 
 	return output, nil
+}
+
+func (p *CheckPipeline) makeResult(payload ocr2keepers.UpkeepPayload) ocr2keepers.CheckResult {
+	result := ocr2keepers.CheckResult{
+		PipelineExecutionState: 0,
+		Retryable:              false,
+		Eligible:               false,
+		IneligibilityReason:    0,
+		UpkeepID:               payload.UpkeepID,
+		Trigger:                payload.Trigger,
+		WorkID:                 payload.WorkID,
+		GasAllocated:           5_000_000, // TODO: make this configurable
+		PerformData:            []byte{},  // TODO: add perform data from configuration
+		FastGasWei:             big.NewInt(1_000_000),
+		LinkNative:             big.NewInt(1_000_000),
+	}
+
+	block := new(big.Int).SetInt64(int64(payload.Trigger.BlockNumber))
+	performs := p.performs.PerformsForUpkeepID(payload.UpkeepID.String())
+
+	if simulated, ok := p.active.GetByUpkeepID(payload.UpkeepID); ok {
+		if simulated.AlwaysEligible {
+			result.Eligible = true
+		} else {
+			result.Eligible = isEligible(simulated.EligibleAt, performs, block)
+		}
+
+		execState := uint8(simulated.States.GetNextState())
+		if execState != 0 {
+			result.PipelineExecutionState = execState
+			result.Retryable = simulated.Retryable
+		}
+
+		p.logger.Printf("%s eligibility %t at block %d", payload.UpkeepID, result.Eligible, block)
+	} else {
+		p.logger.Printf("%s is not active", payload.UpkeepID)
+	}
+
+	return result
 }
 
 func isEligible(eligibles, performs []*big.Int, block *big.Int) bool {

--- a/tools/simulator/simulate/upkeep/pipeline_test.go
+++ b/tools/simulator/simulate/upkeep/pipeline_test.go
@@ -37,8 +37,9 @@ func TestCheckPipeline(t *testing.T) {
 	}
 
 	upkeep1 := chain.SimulatedUpkeep{
-		ID:   big.NewInt(10),
-		Type: chain.LogTriggerType,
+		ID:     big.NewInt(10),
+		Type:   chain.LogTriggerType,
+		States: mustCreatePipelineState(""),
 	}
 
 	trigger1 := ocr2keepers.NewLogTrigger(
@@ -151,6 +152,15 @@ func loadUpkeepAt(upkeep chain.SimulatedUpkeep, atBlock int64) func(*chain.Block
 			})
 		}
 	}
+}
+
+func mustCreatePipelineState(pattern string) *chain.CheckPipelineStateManager {
+	manager, err := chain.NewCheckPipelineStateManager(pattern)
+	if err != nil {
+		panic(err)
+	}
+
+	return manager
 }
 
 type mockNetTelemetry struct {


### PR DESCRIPTION
This commit adds a configuration for applying overrides to generated upkeeps. One specific override is to apply failures to `PipelineExecutionState` using a pattern.