### PR TITLE
reduce log message length

### DIFF
--- a/pkg/v3/observer.go
+++ b/pkg/v3/observer.go
@@ -111,7 +111,10 @@ func (o *Observer[T]) Process(ctx context.Context, tick tickers.Tick[[]T]) error
 		return err
 	}
 
-	o.lggr.Printf("finished processing of %d results: %+v", len(results), results)
+	o.lggr.Printf("finished processing of %d results", len(results))
+	for i, result := range results {
+		o.lggr.Printf("result %d: %+v", i+1, result)
+	}
 
 	return nil
 }


### PR DESCRIPTION
Including full results produces large log lines, up to 170KiB.